### PR TITLE
Add custom waterfall-history card and update resource reference in Lovelace

### DIFF
--- a/lovelace/lovelace.dashboard_analysis.yaml
+++ b/lovelace/lovelace.dashboard_analysis.yaml
@@ -692,6 +692,26 @@ config:
       theme: optimal_when_high
       type: custom:entity-progress-card
       unit: flextimer
+    - columns: 12
+      digits: 2
+      entity: sensor.boiler_temperature
+      gradient: false
+      height: 60
+      hours: 24
+      intervals: 1
+      show_labels: true
+      show_min_max: true
+      thresholds:
+      - color: '#4FC3F7'
+        value: 30
+      - color: '#81C784'
+        value: 40
+      - color: '#FFB74D'
+        value: 50
+      - color: '#FF8A65'
+        value: 60
+      title: Temperature History
+      type: custom:waterfall-history-card
     icon: mdi:home-analytics
     title: Analytics
   - badges: []

--- a/lovelace/lovelace_resources.yaml
+++ b/lovelace/lovelace_resources.yaml
@@ -154,7 +154,7 @@ items:
   url: /hacsfiles/simple-swipe-card/simple-swipe-card.js?hacstag=970744650170
 - id: c1f6894708544bc89cdef06d4f328dd4
   type: module
-  url: /hacsfiles/horizontal-waterfall-history-card/horizontal-waterfall-history-card.js?hacstag=98915322703
+  url: /hacsfiles/horizontal-waterfall-history-card/horizontal-waterfall-history-card.js?hacstag=98915322704
 - id: 1c6874666863483c80341bd2685cc02d
   type: module
   url: /hacsfiles/jk-bms-card/jk-bms-card.js?hacstag=974898979112


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new card to the dashboard displaying the 24-hour temperature history for the boiler, including color-coded thresholds and detailed labels.

- **Chores**
  - Updated the resource version for the waterfall history card to ensure the latest changes are loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->