### PR TITLE
Update Lovelace dashboards to add and restructure BMS cards and remove warnings

### DIFF
--- a/lovelace/lovelace.dashboard_analysis.yaml
+++ b/lovelace/lovelace.dashboard_analysis.yaml
@@ -1688,7 +1688,9 @@ config:
     title: '3d printer '
     visible:
     - user: 4f7767cac0c342edb25e991662a2f56c
-  - max_columns: 4
+  - cards: []
+    icon: mdi:lightning-bolt-circle
+    max_columns: 4
     path: known-power-energy-diagnostics
     sections:
     - cards:
@@ -2597,6 +2599,124 @@ config:
       tap_action:
         action: none
       type: custom:entity-progress-card
+    - cellColumns: 4
+      cellCount: 16
+      cellLayout: bankMode
+      entities:
+        average_cell_voltage: sensor.felicity_ess_bat2_average_cell_voltage
+        balance_trigger_voltage: ''
+        balancer: ''
+        balancing_current: ''
+        capacity_remaining: sensor.felicity_ess_bat2_remaining_energy
+        cell_resistance_1: ''
+        cell_resistance_10: ''
+        cell_resistance_11: ''
+        cell_resistance_12: ''
+        cell_resistance_13: ''
+        cell_resistance_14: ''
+        cell_resistance_15: ''
+        cell_resistance_16: ''
+        cell_resistance_2: ''
+        cell_resistance_3: ''
+        cell_resistance_4: ''
+        cell_resistance_5: ''
+        cell_resistance_6: ''
+        cell_resistance_7: ''
+        cell_resistance_8: ''
+        cell_resistance_9: ''
+        cell_voltage_1: sensor.felicity_ess_bat2_cell_01
+        cell_voltage_10: sensor.felicity_ess_bat2_cell_10
+        cell_voltage_11: sensor.felicity_ess_bat2_cell_11
+        cell_voltage_12: sensor.felicity_ess_bat2_cell_12
+        cell_voltage_13: sensor.felicity_ess_bat2_cell_13
+        cell_voltage_14: sensor.felicity_ess_bat2_cell_14
+        cell_voltage_15: sensor.felicity_ess_bat2_cell_15
+        cell_voltage_16: sensor.felicity_ess_bat2_cell_16
+        cell_voltage_2: sensor.felicity_ess_bat2_cell_02
+        cell_voltage_3: sensor.felicity_ess_bat2_cell_03
+        cell_voltage_4: sensor.felicity_ess_bat2_cell_04
+        cell_voltage_5: sensor.felicity_ess_bat2_cell_05
+        cell_voltage_6: sensor.felicity_ess_bat2_cell_06
+        cell_voltage_7: sensor.felicity_ess_bat2_cell_07
+        cell_voltage_8: sensor.felicity_ess_bat2_cell_08
+        cell_voltage_9: sensor.felicity_ess_bat2_cell_09
+        charging: ''
+        charging_cycles: sensor.inverter_total_battery_life_cycles
+        current: sensor.felicity_ess_bat2_current
+        delta_cell_voltage: sensor.felicity_ess_bat2_cell_voltage_difference
+        discharging: ''
+        errors: sensor.felicity_ess_bat2_fault_status
+        max_voltage_cell: ''
+        min_voltage_cell: ''
+        power: sensor.felicity_ess_bat2_power
+        power_tube_temperature: sensor.felicity_ess_bat2_bms_temperature
+        state_of_charge: sensor.felicity_ess_bat2_soc
+        total_battery_capacity_setting: number.felicity_ess_battery2_capacity_capacity
+        total_charging_cycle_capacity: ''
+        total_runtime_formatted: ''
+        total_voltage: sensor.felicity_ess_bat2_voltage
+      prefix: jk_bms
+      title: Battery 2
+      type: custom:jk-bms-card
+    - cellColumns: 4
+      cellCount: 16
+      cellLayout: bankMode
+      entities:
+        average_cell_voltage: sensor.felicity_ess_bat1_average_cell_voltage
+        balance_trigger_voltage: ''
+        balancer: ''
+        balancing_current: ''
+        capacity_remaining: sensor.felicity_ess_bat1_remaining_energy
+        cell_resistance_1: ''
+        cell_resistance_10: ''
+        cell_resistance_11: ''
+        cell_resistance_12: ''
+        cell_resistance_13: ''
+        cell_resistance_14: ''
+        cell_resistance_15: ''
+        cell_resistance_16: ''
+        cell_resistance_2: ''
+        cell_resistance_3: ''
+        cell_resistance_4: ''
+        cell_resistance_5: ''
+        cell_resistance_6: ''
+        cell_resistance_7: ''
+        cell_resistance_8: ''
+        cell_resistance_9: ''
+        cell_voltage_1: sensor.felicity_ess_bat1_cell_01
+        cell_voltage_10: sensor.felicity_ess_bat1_cell_10
+        cell_voltage_11: sensor.felicity_ess_bat1_cell_11
+        cell_voltage_12: sensor.felicity_ess_bat1_cell_12
+        cell_voltage_13: sensor.felicity_ess_bat1_cell_13
+        cell_voltage_14: sensor.felicity_ess_bat1_cell_14
+        cell_voltage_15: sensor.felicity_ess_bat1_cell_15
+        cell_voltage_16: sensor.felicity_ess_bat1_cell_16
+        cell_voltage_2: sensor.felicity_ess_bat1_cell_02
+        cell_voltage_3: sensor.felicity_ess_bat1_cell_03
+        cell_voltage_4: sensor.felicity_ess_bat1_cell_04
+        cell_voltage_5: sensor.felicity_ess_bat1_cell_05
+        cell_voltage_6: sensor.felicity_ess_bat1_cell_06
+        cell_voltage_7: sensor.felicity_ess_bat1_cell_07
+        cell_voltage_8: sensor.felicity_ess_bat1_cell_08
+        cell_voltage_9: sensor.felicity_ess_bat1_cell_09
+        charging: ''
+        charging_cycles: sensor.inverter_total_battery_life_cycles
+        current: sensor.felicity_ess_bat1_current
+        delta_cell_voltage: sensor.felicity_ess_bat1_cell_voltage_difference
+        discharging: ''
+        errors: sensor.felicity_ess_bat1_fault_status
+        max_voltage_cell: ''
+        min_voltage_cell: ''
+        power: sensor.felicity_ess_bat1_power
+        power_tube_temperature: sensor.felicity_ess_bat1_bms_temperature
+        state_of_charge: sensor.felicity_ess_bat1_soc
+        total_battery_capacity_setting: number.felicity_ess_battery1_capacity
+        total_charging_cycle_capacity: ''
+        total_runtime_formatted: ''
+        total_voltage: sensor.felicity_ess_bat1_voltage
+      prefix: jk_bms
+      title: Battery 1
+      type: custom:jk-bms-card
     path: test
     subview: true
     title: test

--- a/lovelace/lovelace.yaml
+++ b/lovelace/lovelace.yaml
@@ -1682,50 +1682,6 @@ config:
       showMultiDay: true
       showMultiDayEventParts: true
       type: custom:atomic-calendar-revive
-    - card:
-        style: "ha-card {\n  background-color: rgba(255, 80, 80, 0.2);\n  font-size:\
-          \ 16px;\n  text-align: auto;\n}\n"
-        type: entities
-      entities:
-      - attribute: headline
-        entity: binary_sensor.warning_rauenberg_stadt_rhein_neckar_kreis_baden_wurttemberg_1
-        image: /local/Nina_app.jpg
-        name: Rauenberg
-        type: attribute
-      - attribute: headline
-        entity: binary_sensor.warning_rauenberg_stadt_rhein_neckar_kreis_baden_wurttemberg_2
-        icon: []
-        name: []
-        type: attribute
-      filter:
-        exclude:
-        - state: 'off'
-      show_empty: false
-      sort:
-        method: none
-      type: custom:auto-entities
-    - card:
-        style: "ha-card {\n  background-color: rgba(255, 80, 80, 0.2);\n  font-size:\
-          \ 16px;\n  text-align: auto;\n}\n"
-        type: entities
-      entities:
-      - attribute: headline
-        entity: binary_sensor.warning_bruchsal_stadt_karlsruhe_baden_wurttemberg_1
-        image: /local/Nina_app.jpg
-        name: Bruchsal
-        type: attribute
-      - attribute: headline
-        entity: binary_sensor.warning_bruchsal_stadt_karlsruhe_baden_wurttemberg_2
-        icon: []
-        name: []
-        type: attribute
-      filter:
-        exclude:
-        - state: 'off'
-      show_empty: false
-      sort:
-        method: none
-      type: custom:auto-entities
     icon: mdi:home
     path: overview
     title: Overview
@@ -9052,124 +9008,135 @@ config:
         start: day
       type: custom:apexcharts-card
       update_interval: 30sec
-    - cellColumns: 4
-      cellCount: 16
-      cellLayout: bankMode
-      entities:
-        average_cell_voltage: sensor.felicity_ess_bat2_average_cell_voltage
-        balance_trigger_voltage: ''
-        balancer: ''
-        balancing_current: ''
-        capacity_remaining: sensor.felicity_ess_bat2_remaining_energy
-        cell_resistance_1: ''
-        cell_resistance_10: ''
-        cell_resistance_11: ''
-        cell_resistance_12: ''
-        cell_resistance_13: ''
-        cell_resistance_14: ''
-        cell_resistance_15: ''
-        cell_resistance_16: ''
-        cell_resistance_2: ''
-        cell_resistance_3: ''
-        cell_resistance_4: ''
-        cell_resistance_5: ''
-        cell_resistance_6: ''
-        cell_resistance_7: ''
-        cell_resistance_8: ''
-        cell_resistance_9: ''
-        cell_voltage_1: sensor.felicity_ess_bat2_cell_01
-        cell_voltage_10: sensor.felicity_ess_bat2_cell_10
-        cell_voltage_11: sensor.felicity_ess_bat2_cell_11
-        cell_voltage_12: sensor.felicity_ess_bat2_cell_12
-        cell_voltage_13: sensor.felicity_ess_bat2_cell_13
-        cell_voltage_14: sensor.felicity_ess_bat2_cell_14
-        cell_voltage_15: sensor.felicity_ess_bat2_cell_15
-        cell_voltage_16: sensor.felicity_ess_bat2_cell_16
-        cell_voltage_2: sensor.felicity_ess_bat2_cell_02
-        cell_voltage_3: sensor.felicity_ess_bat2_cell_03
-        cell_voltage_4: sensor.felicity_ess_bat2_cell_04
-        cell_voltage_5: sensor.felicity_ess_bat2_cell_05
-        cell_voltage_6: sensor.felicity_ess_bat2_cell_06
-        cell_voltage_7: sensor.felicity_ess_bat2_cell_07
-        cell_voltage_8: sensor.felicity_ess_bat2_cell_08
-        cell_voltage_9: sensor.felicity_ess_bat2_cell_09
-        charging: ''
-        charging_cycles: sensor.inverter_total_battery_life_cycles
-        current: sensor.felicity_ess_bat2_current
-        delta_cell_voltage: sensor.felicity_ess_bat2_cell_voltage_difference
-        discharging: ''
-        errors: sensor.felicity_ess_bat2_fault_status
-        max_voltage_cell: ''
-        min_voltage_cell: ''
-        power: sensor.felicity_ess_bat2_power
-        power_tube_temperature: sensor.felicity_ess_bat2_bms_temperature
-        state_of_charge: sensor.felicity_ess_bat2_soc
-        total_battery_capacity_setting: number.felicity_ess_battery2_capacity_capacity
-        total_charging_cycle_capacity: ''
-        total_runtime_formatted: ''
-        total_voltage: sensor.felicity_ess_bat2_voltage
-      prefix: jk_bms
-      title: Battery 2
-      type: custom:jk-bms-card
-    - cellColumns: 4
-      cellCount: 16
-      cellLayout: bankMode
-      entities:
-        average_cell_voltage: sensor.felicity_ess_bat1_average_cell_voltage
-        balance_trigger_voltage: ''
-        balancer: ''
-        balancing_current: ''
-        capacity_remaining: sensor.felicity_ess_bat1_remaining_energy
-        cell_resistance_1: ''
-        cell_resistance_10: ''
-        cell_resistance_11: ''
-        cell_resistance_12: ''
-        cell_resistance_13: ''
-        cell_resistance_14: ''
-        cell_resistance_15: ''
-        cell_resistance_16: ''
-        cell_resistance_2: ''
-        cell_resistance_3: ''
-        cell_resistance_4: ''
-        cell_resistance_5: ''
-        cell_resistance_6: ''
-        cell_resistance_7: ''
-        cell_resistance_8: ''
-        cell_resistance_9: ''
-        cell_voltage_1: sensor.felicity_ess_bat1_cell_01
-        cell_voltage_10: sensor.felicity_ess_bat1_cell_10
-        cell_voltage_11: sensor.felicity_ess_bat1_cell_11
-        cell_voltage_12: sensor.felicity_ess_bat1_cell_12
-        cell_voltage_13: sensor.felicity_ess_bat1_cell_13
-        cell_voltage_14: sensor.felicity_ess_bat1_cell_14
-        cell_voltage_15: sensor.felicity_ess_bat1_cell_15
-        cell_voltage_16: sensor.felicity_ess_bat1_cell_16
-        cell_voltage_2: sensor.felicity_ess_bat1_cell_02
-        cell_voltage_3: sensor.felicity_ess_bat1_cell_03
-        cell_voltage_4: sensor.felicity_ess_bat1_cell_04
-        cell_voltage_5: sensor.felicity_ess_bat1_cell_05
-        cell_voltage_6: sensor.felicity_ess_bat1_cell_06
-        cell_voltage_7: sensor.felicity_ess_bat1_cell_07
-        cell_voltage_8: sensor.felicity_ess_bat1_cell_08
-        cell_voltage_9: sensor.felicity_ess_bat1_cell_09
-        charging: ''
-        charging_cycles: sensor.inverter_total_battery_life_cycles
-        current: sensor.felicity_ess_bat1_current
-        delta_cell_voltage: sensor.felicity_ess_bat1_cell_voltage_difference
-        discharging: ''
-        errors: sensor.felicity_ess_bat1_fault_status
-        max_voltage_cell: ''
-        min_voltage_cell: ''
-        power: sensor.felicity_ess_bat1_power
-        power_tube_temperature: sensor.felicity_ess_bat1_bms_temperature
-        state_of_charge: sensor.felicity_ess_bat1_soc
-        total_battery_capacity_setting: number.felicity_ess_battery1_capacity
-        total_charging_cycle_capacity: ''
-        total_runtime_formatted: ''
-        total_voltage: sensor.felicity_ess_bat1_voltage
-      prefix: jk_bms
-      title: Battery 1
-      type: custom:jk-bms-card
+    - auto_swipe_interval: 15000
+      card_spacing: 15
+      cards:
+      - cellColumns: 4
+        cellCount: 16
+        cellLayout: bankMode
+        entities:
+          average_cell_voltage: sensor.felicity_ess_bat1_average_cell_voltage
+          balance_trigger_voltage: ''
+          balancer: ''
+          balancing_current: ''
+          capacity_remaining: sensor.felicity_ess_bat1_remaining_energy
+          cell_resistance_1: ''
+          cell_resistance_10: ''
+          cell_resistance_11: ''
+          cell_resistance_12: ''
+          cell_resistance_13: ''
+          cell_resistance_14: ''
+          cell_resistance_15: ''
+          cell_resistance_16: ''
+          cell_resistance_2: ''
+          cell_resistance_3: ''
+          cell_resistance_4: ''
+          cell_resistance_5: ''
+          cell_resistance_6: ''
+          cell_resistance_7: ''
+          cell_resistance_8: ''
+          cell_resistance_9: ''
+          cell_voltage_1: sensor.felicity_ess_bat1_cell_01
+          cell_voltage_10: sensor.felicity_ess_bat1_cell_10
+          cell_voltage_11: sensor.felicity_ess_bat1_cell_11
+          cell_voltage_12: sensor.felicity_ess_bat1_cell_12
+          cell_voltage_13: sensor.felicity_ess_bat1_cell_13
+          cell_voltage_14: sensor.felicity_ess_bat1_cell_14
+          cell_voltage_15: sensor.felicity_ess_bat1_cell_15
+          cell_voltage_16: sensor.felicity_ess_bat1_cell_16
+          cell_voltage_2: sensor.felicity_ess_bat1_cell_02
+          cell_voltage_3: sensor.felicity_ess_bat1_cell_03
+          cell_voltage_4: sensor.felicity_ess_bat1_cell_04
+          cell_voltage_5: sensor.felicity_ess_bat1_cell_05
+          cell_voltage_6: sensor.felicity_ess_bat1_cell_06
+          cell_voltage_7: sensor.felicity_ess_bat1_cell_07
+          cell_voltage_8: sensor.felicity_ess_bat1_cell_08
+          cell_voltage_9: sensor.felicity_ess_bat1_cell_09
+          charging: ''
+          charging_cycles: sensor.inverter_total_battery_life_cycles
+          current: sensor.felicity_ess_bat1_current
+          delta_cell_voltage: sensor.felicity_ess_bat1_cell_voltage_difference
+          discharging: ''
+          errors: sensor.felicity_ess_bat1_fault_status
+          max_voltage_cell: ''
+          min_voltage_cell: ''
+          power: sensor.felicity_ess_bat1_power
+          power_tube_temperature: sensor.felicity_ess_bat1_bms_temperature
+          state_of_charge: sensor.felicity_ess_bat1_soc
+          total_battery_capacity_setting: number.felicity_ess_battery1_capacity
+          total_charging_cycle_capacity: ''
+          total_runtime_formatted: ''
+          total_voltage: sensor.felicity_ess_bat1_voltage
+        prefix: jk_bms
+        title: Battery 1
+        type: custom:jk-bms-card
+      - cellColumns: 4
+        cellCount: 16
+        cellLayout: bankMode
+        entities:
+          average_cell_voltage: sensor.felicity_ess_bat2_average_cell_voltage
+          balance_trigger_voltage: ''
+          balancer: ''
+          balancing_current: ''
+          capacity_remaining: sensor.felicity_ess_bat2_remaining_energy
+          cell_resistance_1: ''
+          cell_resistance_10: ''
+          cell_resistance_11: ''
+          cell_resistance_12: ''
+          cell_resistance_13: ''
+          cell_resistance_14: ''
+          cell_resistance_15: ''
+          cell_resistance_16: ''
+          cell_resistance_2: ''
+          cell_resistance_3: ''
+          cell_resistance_4: ''
+          cell_resistance_5: ''
+          cell_resistance_6: ''
+          cell_resistance_7: ''
+          cell_resistance_8: ''
+          cell_resistance_9: ''
+          cell_voltage_1: sensor.felicity_ess_bat2_cell_01
+          cell_voltage_10: sensor.felicity_ess_bat2_cell_10
+          cell_voltage_11: sensor.felicity_ess_bat2_cell_11
+          cell_voltage_12: sensor.felicity_ess_bat2_cell_12
+          cell_voltage_13: sensor.felicity_ess_bat2_cell_13
+          cell_voltage_14: sensor.felicity_ess_bat2_cell_14
+          cell_voltage_15: sensor.felicity_ess_bat2_cell_15
+          cell_voltage_16: sensor.felicity_ess_bat2_cell_16
+          cell_voltage_2: sensor.felicity_ess_bat2_cell_02
+          cell_voltage_3: sensor.felicity_ess_bat2_cell_03
+          cell_voltage_4: sensor.felicity_ess_bat2_cell_04
+          cell_voltage_5: sensor.felicity_ess_bat2_cell_05
+          cell_voltage_6: sensor.felicity_ess_bat2_cell_06
+          cell_voltage_7: sensor.felicity_ess_bat2_cell_07
+          cell_voltage_8: sensor.felicity_ess_bat2_cell_08
+          cell_voltage_9: sensor.felicity_ess_bat2_cell_09
+          charging: ''
+          charging_cycles: sensor.inverter_total_battery_life_cycles
+          current: sensor.felicity_ess_bat2_current
+          delta_cell_voltage: sensor.felicity_ess_bat2_cell_voltage_difference
+          discharging: ''
+          errors: sensor.felicity_ess_bat2_fault_status
+          max_voltage_cell: ''
+          min_voltage_cell: ''
+          power: sensor.felicity_ess_bat2_power
+          power_tube_temperature: sensor.felicity_ess_bat2_bms_temperature
+          state_of_charge: sensor.felicity_ess_bat2_soc
+          total_battery_capacity_setting: number.felicity_ess_battery2_capacity_capacity
+          total_charging_cycle_capacity: ''
+          total_runtime_formatted: ''
+          total_voltage: sensor.felicity_ess_bat2_voltage
+        prefix: jk_bms
+        title: Battery 2
+        type: custom:jk-bms-card
+      enable_auto_swipe: false
+      enable_loopback: true
+      enable_reset_after: true
+      reset_after_timeout: 30000
+      reset_target_card: 1
+      show_pagination: false
+      swipe_direction: horizontal
+      type: custom:simple-swipe-card
     icon: mdi:fuel-cell
     path: solar-battery
     subview: true


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added two new battery management system (BMS) display cards for "Battery 1" and "Battery 2" in the dashboard, providing detailed battery metrics and status.

- **Improvements**
  - Updated the "Solar Battery" view to combine both battery cards into a single swipeable card, allowing users to switch between battery displays with a swipe gesture.

- **Removals**
  - Removed warning cards for Rauenberg and Bruchsal locations from the "Overview" view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->