### PR TITLE
Add shell command to delete old weekly backups in backup deletion automation

### DIFF
--- a/config/automations.yaml
+++ b/config/automations.yaml
@@ -7174,6 +7174,9 @@
   - action: shell_command.delete_old_backups_disk
     metadata: {}
     data: {}
+  - action: shell_command.delete_old_weekly_backus_disk
+    metadata: {}
+    data: {}
   mode: single
 - id: '1746353652230'
   alias: Wohnzimmer Restore


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the backup management automation to include an additional cleanup step for weekly backups when storage is low.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->