### PR TITLE
Fix typo in delete_old_weekly_backups_disk command and configuration

### DIFF
--- a/config/automations.yaml
+++ b/config/automations.yaml
@@ -7174,7 +7174,7 @@
   - action: shell_command.delete_old_backups_disk
     metadata: {}
     data: {}
-  - action: shell_command.delete_old_weekly_backus_disk
+  - action: shell_command.delete_old_weekly_backups_disk
     metadata: {}
     data: {}
   mode: single

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -162,7 +162,7 @@ shell_command:
   call_timelapse_script: /config/Ffmpeg_timeplase.sh {{output_filename}}
   delete_files_webcam1: 'rm -f /media/m5ccam/pictures/*.jpg'
   delete_old_backups_disk: "find /share/USBMEDIABACKUP_Share/Backup/ -name 'DailyBackup*' -type f -mtime +14 -delete"
-  delete_old_weekly_backus_disk: "find /share/USBMEDIABACKUP_Share/Backup/ -name 'WeeklyBackup*.tar' -type f -mtime +30 -delete"
+  delete_old_weekly_backups_disk: "find /share/USBMEDIABACKUP_Share/Backup/ -name 'WeeklyBackup*.tar' -type f -mtime +30 -delete"
 
 ingress:
   o2:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typographical error in the backup deletion automation and related command, ensuring proper execution of weekly backup cleanup when storage is low.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->