### PR TITLE
Add horizontal stack of four WebRTC camera cards to Camera view

### DIFF
--- a/lovelace/lovelace.fire_hd_8.yaml
+++ b/lovelace/lovelace.fire_hd_8.yaml
@@ -2784,30 +2784,83 @@ config:
         - type: custom:gap-card
         type: horizontal-stack
       - cards:
+        - muted: true
+          server: http://192.168.2.205:1984/
+          streams:
+          - name: HD
+            url: autos_tapo
+          - name: SD
+            url: autos_tapo_detect
+          style: '.pictureinpicture {display: none} .screenshot {display: none}'
+          type: custom:webrtc-camera
+          ui: true
+        - muted: true
+          server: http://192.168.2.205:1984/
+          streams:
+          - name: HD
+            url: ding_dong_tapo
+          - name: SD
+            url: ding_dong_tapo_detect
+          style: '.pictureinpicture {display: none} .screenshot {display: none}'
+          type: custom:webrtc-camera
+          ui: true
+        - muted: true
+          server: http://192.168.2.205:1984/
+          streams:
+          - name: HD
+            url: keller_tapo
+          - name: SD
+            url: keller_tapo_detect
+          style: '.pictureinpicture {display: none} .screenshot {display: none}'
+          type: custom:webrtc-camera
+          ui: true
+        - muted: true
+          server: http://192.168.2.205:1984/
+          streams:
+          - name: HD
+            url: terrasse_tapo
+          - name: SD
+            url: terrasse_tapo_detect
+          style: '.pictureinpicture {display: none} .screenshot {display: none}'
+          type: custom:webrtc-camera
+          ui: true
         - camera_image: camera.autos_hd_stream
           camera_view: live
           entity: camera.autos_hd_stream
+          fit_mode: cover
           show_name: false
           show_state: false
           type: picture-entity
+          visibility:
+          - condition: user
+            users: []
         - camera_image: camera.ding_dong_hd_stream
           camera_view: live
           entity: camera.ding_dong_hd_stream
           show_name: false
           show_state: false
           type: picture-entity
+          visibility:
+          - condition: user
+            users: []
         - camera_image: camera.keller_hd_stream
           camera_view: live
           entity: camera.keller_hd_stream
           show_name: false
           show_state: false
           type: picture-entity
+          visibility:
+          - condition: user
+            users: []
         - camera_image: camera.terrasse_hd_stream
           camera_view: live
           entity: camera.terrasse_hd_stream
           show_name: false
           show_state: false
           type: picture-entity
+          visibility:
+          - condition: user
+            users: []
         columns: 2
         square: false
         type: grid


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a horizontal stack of four custom WebRTC camera cards on the "Camera" view, each with selectable HD/SD streams, muted audio, and enhanced UI controls.

- **Style**
  - Updated camera cards to hide picture-in-picture and screenshot buttons for a cleaner interface.

- **Refactor**
  - Existing picture-entity camera cards are now hidden from all users and display images using a "cover" fit mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->