### PR TITLE
Restructure markdown card to nest domains in expandable details sections

### DIFF
--- a/lovelace/lovelace.dashboard_analysis.yaml
+++ b/lovelace/lovelace.dashboard_analysis.yaml
@@ -577,23 +577,13 @@ config:
         type: custom:mushroom-template-card
       title-card-button-overlay: false
       type: custom:expander-card
-    - button-background: transparent
-      cards:
-      - content: "{% set x = ['unavailable','unknown'] %}\n{%- for d in states|groupby('domain')\
-          \ %}\n  {% if loop.first %} \n  Domains: {{loop.length}}\n  {% endif %}\n\
-          \  <details>\n  <summary>{{- d[0] | title }}: <b>{{states[d[0]]|rejectattr('state','in',x)|list|count}}</b></summary>\n\
-          \  {% for i in d[1] if i.state not in x -%}\n  &nbsp;&nbsp;&nbsp;&nbsp;-\
-          \ {{i.name}}: <b>{{i.state}}</b><br>\n  {% endfor %}\n  </details>\n{%-\
-          \ endfor -%}"
-        type: markdown
-      child-padding: 0.0em
-      clear: false
-      gap: 0.1em
-      overlay-margin: 0.0em
-      padding: 0.1em
-      title: Domains & their Entities
-      title-card-button-overlay: false
-      type: custom:expander-card
+    - content: "{% set x = ['unavailable','unknown'] %}\n<details>\n{%- for d in states|groupby('domain')\
+        \ %}\n  {% if loop.first %} \n  <summary><b>Domains: {{loop.length}}</b> </summary>\n\
+        \  {% endif %}\n  <details>\n  <summary>{{- d[0] | title }}: <b>{{states[d[0]]|rejectattr('state','in',x)|list|count}}</b></summary>\n\
+        \  {% for i in d[1] if i.state not in x -%}\n  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-\
+        \ {{i.name}}: <b>{{i.state}}</b><br>\n  {% endfor %}\n  </details>\n{%- endfor\
+        \ -%}\n</details>"
+      type: markdown
     - entity: sensor.backup_state
       fill_container: true
       icon: mdi:clipboard-check-multiple-outline


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the structure of the dashboard's expandable entity summary by nesting all domain groups under a single expandable section, making it easier to view and navigate grouped entities and their states.
	- Enhanced readability with better indentation and formatting in the entity list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->