### PR TITLE
Replace garage door battery badge with progress card in Lovelace UI

### DIFF
--- a/lovelace/lovelace.yaml
+++ b/lovelace/lovelace.yaml
@@ -5413,6 +5413,36 @@ config:
           point: hover
           points: hover
         type: custom:mini-graph-card
+      - bar_color: "{% set pool_temp = states('sensor.esp32_c3_mini_pool_temperature_pool_temperature')\
+          \ | float(0) %}\n{% if pool_temp > 30.0 %}\n  red\n{% elif pool_temp > 26.0\
+          \ %}\n  orange\n{% elif pool_temp > 22.0 %}\n  yellow\n{% else %} {# This\
+          \ covers pool_temp <= 22.0 #}\n  lightblue\n{% endif %}"
+        color: "{% set pool_temp = states('sensor.esp32_c3_mini_pool_temperature_pool_temperature')\
+          \ | float(0) %}\n{% if pool_temp > 30.0 %}\n  red\n{% elif pool_temp > 26.0\
+          \ %}\n  orange\n{% elif pool_temp > 22.0 %}\n  yellow\n{% else %} {# This\
+          \ covers pool_temp <= 22.0 #}\n  lightblue\n{% endif %}"
+        decimal: 1
+        entity: sensor.esp32_c3_mini_pool_temperature_pool_temperature
+        grid_options:
+          columns: 12
+          rows: 1
+        max_value: 40
+        min_value: 10
+        name: "Pool Temperature: {{states('sensor.esp32_c3_mini_pool_temperature_pool_temperature')\
+          \ | float(0) | round(2) }}\xB0C"
+        percent: "{% set min_pool_temp = 10 %}\n{% set max_pool_temp = 40 %}\n{% set\
+          \ current_pool_temp = states('sensor.esp32_c3_mini_pool_temperature_pool_temperature')\
+          \ | float(-999) %}\n{% set normalized_percentage = 0 %}\n\n{% if current_pool_temp\
+          \ == -999 %}\n  {# Handle cases where the sensor state is unavailable or\
+          \ not a valid number #}\n  {% set normalized_percentage = 0 %}\n{% elif\
+          \ current_pool_temp <= min_pool_temp %}\n  {% set normalized_percentage\
+          \ = 0 %}\n{% elif current_pool_temp >= max_pool_temp %}\n  {% set normalized_percentage\
+          \ = 100 %}\n{% else %}\n  {% set normalized_percentage = ((current_pool_temp\
+          \ - min_pool_temp) / (max_pool_temp - min_pool_temp) * 100) | round(2) %}\n\
+          {% endif %}\n{{ normalized_percentage }}"
+        secondary: "Day Start: {{ states('input_number.pool_temp_start') | float(0)\
+          \ | round(2) }}\xB0C"
+        type: custom:entity-progress-card-template
       - cards:
         - entity: sensor.pool_temp_low
           fill_container: true


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a progress card to the Garage view to display the garage door battery level when it drops below 40%, providing a clearer visual indicator.
	- Introduced a new progress card in the Pool section to show pool temperature with dynamic coloring and percentage, enhancing temperature monitoring.
- **Refactor**
	- Removed the previous battery badge from the Garage view for a streamlined appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->