### PR TITLE
Move battery sensor to badge, adjust grid columns, shorten pool label

### DIFF
--- a/lovelace/lovelace.yaml
+++ b/lovelace/lovelace.yaml
@@ -2904,12 +2904,12 @@ config:
       type: grid
     - cards:
       - badges:
-        - entity: input_select.go_e_select_card
+        - color: state
+          entity: sensor.felicity_ess_soc_avg
           show_icon: true
           show_state: true
           type: entity
-        - color: state
-          entity: sensor.felicity_ess_soc_avg
+        - entity: input_select.go_e_select_card
           show_icon: true
           show_state: true
           type: entity


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated the "goe" view to display the battery sensor as a color-coded badge, always visible.
  - Reduced the maximum number of columns in the "goe" grid from 4 to 3 for improved layout.
  - Shortened the secondary label text in the pool temperature card from "Day Start:" to "Start:" in the "pool" view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->