### PR TITLE
Add visibility condition to Pollen card in lovelace.yaml based on user and sensor

### DIFF
--- a/lovelace/lovelace.yaml
+++ b/lovelace/lovelace.yaml
@@ -1383,6 +1383,13 @@ config:
         type: custom:auto-entities
       title: Pollen
       type: vertical-stack
+      visibility:
+      - condition: user
+        users:
+        - 4f7767cac0c342edb25e991662a2f56c
+      - above: 0.5
+        condition: numeric_state
+        entity: sensor.pollen_pollution
     - cards:
       - card:
           entity: schedule.boiler_pumpe


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "Pollen" card now only appears for a specific user and when pollen levels are above 0.5, providing personalized and relevant information display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->