### PR TITLE
Update Lovelace UI with new badges, sun card threshold, and tap action

### DIFF
--- a/lovelace/lovelace.fire_hd_8.yaml
+++ b/lovelace/lovelace.fire_hd_8.yaml
@@ -31,6 +31,26 @@ config:
       - condition: user
         users:
         - 4f7767cac0c342edb25e991662a2f56c
+    - entity: switch.lenovo_tab_p11_bildschirm
+      name: Bildschirm
+      show_icon: true
+      show_name: true
+      show_state: true
+      type: entity
+      visibility:
+      - condition: user
+        users:
+        - 4f7767cac0c342edb25e991662a2f56c
+    - entity: switch.lenovo_tab_p11_bildschirmschoner
+      name: Bildschirmschoner
+      show_icon: true
+      show_name: true
+      show_state: true
+      type: entity
+      visibility:
+      - condition: user
+        users:
+        - 4f7767cac0c342edb25e991662a2f56c
     cards: []
     dense_section_placement: true
     max_columns: 3

--- a/lovelace/lovelace.yaml
+++ b/lovelace/lovelace.yaml
@@ -1691,7 +1691,7 @@ config:
         entity: sun.sun
         name: "N\xE4chster Aufgang: {{ as_datetime(states('sensor.sun_next_rising')).timestamp()\
           \ | timestamp_custom('%H:%M', true) }}"
-        percent: "{% set max_time_difference = 24 * 3600 %}\n{% set next_sunrise_time\
+        percent: "{% set max_time_difference = 25 * 3600 %}\n{% set next_sunrise_time\
           \ = as_datetime(states('sensor.sun_next_rising')) %}\n{% set time_until_next_rise\
           \ = (next_sunrise_time - now()).total_seconds() %}\n{% if time_until_next_rise\
           \ <= 0 %}\n  100\n{% elif time_until_next_rise >= max_time_difference %}\n\
@@ -1712,7 +1712,7 @@ config:
         entity: sun.sun
         name: "N\xE4chster Untergang: {{ as_datetime(states('sensor.sun_next_setting')).timestamp()\
           \ | timestamp_custom('%H:%M', true) }}"
-        percent: "{% set max_time_difference = 24 * 3600 %}\n{% set next_sunrise_time\
+        percent: "{% set max_time_difference = 25 * 3600 %}\n{% set next_sunrise_time\
           \ = as_datetime(states('sensor.sun_next_setting')) %}\n{% set time_until_next_rise\
           \ = (next_sunrise_time - now()).total_seconds() %}\n{% if time_until_next_rise\
           \ <= 0 %}\n  100\n{% elif time_until_next_rise >= max_time_difference %}\n\
@@ -2719,6 +2719,8 @@ config:
           entity: sensor.felicity_ess_soc_avg
           show_icon: true
           show_state: true
+          tap_action:
+            action: more-info
           type: entity
         - entity: input_select.go_e_select_card
           show_icon: true


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added two new entity badges to the Fire HD 8 tablet interface, visible only to a specific user.
  - Enabled tap-to-view detailed information for the average state of charge card in the "Stats" section.

- **Improvements**
  - Extended the time range for sun progress cards, allowing more accurate percentage calculations for sunrise and sunset events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->