### PR TITLE
Add automation statistics line to README and Jinja2 template

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -9,6 +9,8 @@ Description | value
 Number of entities | 2662
 Number of sensors | 1371
 
+Number of automations | 2 inaktive |  108 aktive
+
 ## My installed extensions:
 
 ### Custom integrations

--- a/config/templates/README.j2
+++ b/config/templates/README.j2
@@ -9,6 +9,7 @@ Description | value
 Number of entities | {{states | count}}
 Number of sensors | {{states.sensor | count}}
 
+Number of automations | {{ states.automation | selectattr('state', 'eq', 'off') | list | count }} inaktive |  {{ states.automation | selectattr('state', 'eq', 'on') | list | count }} aktive
 
 ## My installed extensions:
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the README to display the number of active and inactive automations in the Home Assistant statistics section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->