### PR TITLE
Add README to config directory documenting Home Assistant installation

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,95 @@
+# Welcome !
+
+This is my Home Assistant installation.
+
+## Some statistics about my installation:
+
+Description | value
+-- | --
+Number of entities | 2669
+Number of sensors | 1377
+
+Number of automations: 3 inactive and 108 active
+
+## My installed extensions:
+
+### Custom integrations
+- [Ankermake](https://github.com/sondregronas/ankermake-hass-component)
+- [Anniversaries](https://github.com/pinkywafer/Anniversaries)
+- [Anylist](https://github.com/kevdliu/hacs-anylist)
+- [Area Occupancy Detection](https://github.com/Hankanman/Area-Occupancy-Detection)
+- [Attribute As Sensor](https://github.com/gjohansson-ST/attribute_as_sensor)
+- [Auto Backup](https://github.com/jcwillox/hass-auto-backup)
+- [Battery Notes](https://github.com/andrew-codechimp/HA-Battery-Notes)
+- [Device Tools](https://github.com/EuleMitKeule/device-tools)
+- [Dreame Vacuum](https://github.com/Tasshack/dreame-vacuum)
+- [Dwd Pollenflug](https://github.com/mampfes/hacs_dwd_pollenflug)
+- [Dynamic Energy Cost](https://github.com/martinarva/dynamic_energy_cost)
+- [Folding@Homecontrol](https://github.com/eifinger/hass-foldingathomecontrol)
+- [Frigate](https://github.com/blakeblackshear/frigate-hass-integration)
+- [Generate Readme](https://github.com/custom-components/readme)
+- [Go Echarger Integration For Home Assistant Using The Mqtt Api](https://github.com/syssi/homeassistant-goecharger-mqtt)
+- [HACS](https://github.com/hacs/integration)
+- [Home Assistant Wundergroundpws](https://github.com/cytech/Home-Assistant-wundergroundpws)
+- [Honeygain](https://github.com/SplinterHead/ha-honeygain)
+- [Icloud3 V3 Idevice Tracker](https://github.com/gcobb321/icloud3)
+- [Ics Calendar (Icalendar)](https://github.com/franc6/ics_calendar)
+- [Ingress](https://github.com/lovelylain/hass_ingress)
+- [Midea Ac Lan](https://github.com/wuwentao/midea_ac_lan)
+- [Multiscrape](https://github.com/danieldotnl/ha-multiscrape)
+- [Octopus Energy Germany](https://github.com/thecem/octopus_germany)
+- [Scheduler Component](https://github.com/nielsfaber/scheduler-component)
+- [Solarman](https://github.com/davidrapan/ha-solarman)
+- [Solcast Pv Forecast](https://github.com/BJReplay/ha-solcast-solar)
+- [Spook 👻 Your Homie](https://github.com/frenck/spook)
+- [Tapo: Cameras Control](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control)
+- [Tibber Pulse Local](https://github.com/marq24/ha-tibber-pulse-local)
+- [Tuya Local](https://github.com/make-all/tuya-local)
+- [Volkswagen Connect](https://github.com/robinostlund/homeassistant-volkswagencarnet)
+- [Waste Collection Schedule](https://github.com/mampfes/hacs_waste_collection_schedule)
+- [Webrtc Camera](https://github.com/AlexxIT/WebRTC)
+
+### Lovelace plugins
+- [Apexcharts Card](https://github.com/RomRider/apexcharts-card)
+- [Atomic Calendar Revive](https://github.com/totaldebug/atomic-calendar-revive)
+- [Auto Entities](https://github.com/thomasloven/lovelace-auto-entities)
+- [Bubble Card](https://github.com/Clooos/Bubble-Card)
+- [Button Card](https://github.com/custom-cards/button-card)
+- [Card Mod](https://github.com/thomasloven/lovelace-card-mod)
+- [Charger Card](https://github.com/tmjo/charger-card)
+- [Clock Weather Card](https://github.com/pkissling/clock-weather-card)
+- [Config Template Card](https://github.com/iantrich/config-template-card)
+- [Custom Sidebar](https://github.com/elchininet/custom-sidebar)
+- [Energy Flow Card Plus](https://github.com/flixlix/energy-flow-card-plus)
+- [Energy Period Selector Plus](https://github.com/flixlix/energy-period-selector-plus)
+- [Entity Progress Card](https://github.com/francois-le-ko4la/lovelace-entity-progress-card)
+- [Expander Card](https://github.com/MelleD/lovelace-expander-card)
+- [Flexible Horseshoe Card For Lovelace](https://github.com/AmoebeLabs/flex-horseshoe-card)
+- [Gallery Card 2024](https://github.com/lukelalo/gallery-card)
+- [History Explorer Card](https://github.com/SpangleLabs/history-explorer-card)
+- [Home Assistant Swipe Navigation](https://github.com/zanna-37/hass-swipe-navigation)
+- [Jk Bms Card](https://github.com/Pho3niX90/jk-bms-card)
+- [Kiosk Mode](https://github.com/NemesisRE/kiosk-mode)
+- [Mini Graph Card](https://github.com/kalkih/mini-graph-card)
+- [Multiple Entity Row](https://github.com/benct/lovelace-multiple-entity-row)
+- [Mushroom](https://github.com/piitaya/lovelace-mushroom)
+- [Power Flow Card Plus](https://github.com/flixlix/power-flow-card-plus)
+- [Rain Gauge Card](https://github.com/t1gr0u/rain-gauge-card)
+- [Sankey Chart Card](https://github.com/MindFreeze/ha-sankey-chart)
+- [Scheduler Card](https://github.com/nielsfaber/scheduler-card)
+- [Simple Swipe Card](https://github.com/nutteloost/simple-swipe-card)
+- [Stack In Card](https://github.com/custom-cards/stack-in-card)
+- [Sunsynk Power Flow Card](https://github.com/slipx06/sunsynk-power-flow-card)
+- [Swiper Card](https://github.com/ghrsa/swiper-card)
+- [Trashcard](https://github.com/idaho/hassio-trash-card)
+- [Ultra Vehicle Card](https://github.com/WJDDesigns/Ultra-Vehicle-Card)
+- [Uptime Card](https://github.com/dylandoamaral/uptime-card)
+- [Vehicle Status Card](https://github.com/ngocjohn/vehicle-status-card)
+- [Vertical Stack In Card](https://github.com/ofekashery/vertical-stack-in-card)
+- [Weather Radar Card](https://github.com/Makin-Things/weather-radar-card)
+- [Wind Rose Card](https://github.com/aukedejong/lovelace-windrose-card)
+- [Xiaomi Vacuum Map Card](https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card)
+
+***
+
+Generated by the [custom readme integration](https://github.com/custom-components/readme)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a README file in the configuration directory detailing the Home Assistant setup, including entity counts, active/inactive automations, and lists of installed custom integrations and Lovelace plugins with links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->