### PR TITLE
Replace Klima grid view with interactive vertical-stack thermostat layout

### DIFF
--- a/lovelace/lovelace.yaml
+++ b/lovelace/lovelace.yaml
@@ -5058,6 +5058,137 @@ config:
         type: horizontal-stack
       title: Wintergarten Dachfenster
       type: vertical-stack
+    - cards:
+      - cards:
+        - badges:
+          - color: state
+            entity: sensor.og_temperatur
+            show_icon: false
+            show_state: true
+            state_content: state
+            tap_action:
+              action: more-info
+            type: entity
+          entity: input_boolean.show_og_thermostat
+          heading: OG Thermostate
+          heading_style: title
+          icon: mdi:fridge
+          tap_action:
+            action: toggle
+          type: heading
+        - cards:
+          - cards:
+            - entity: climate.153931628718174_climate
+              features_position: bottom
+              grid_options:
+                rows: 1
+              name: Schlafzimmer
+              state_content:
+              - state
+              - temperature
+              - current_temperature
+              type: tile
+              vertical: true
+              visibility:
+              - condition: state
+                entity: climate.153931628718174_climate
+                state_not: unavailable
+            - entity: climate.bad
+              features_position: bottom
+              state_content:
+              - state
+              - current_temperature
+              - temperature
+              type: tile
+              vertical: true
+              visibility:
+              - condition: state
+                entity: climate.bad
+                state_not: unavailable
+            type: horizontal-stack
+          - cards:
+            - entity: climate.kinderbad
+              features_position: bottom
+              state_content:
+              - state
+              - current_temperature
+              - temperature
+              type: tile
+              vertical: true
+              visibility:
+              - condition: state
+                entity: climate.kinderbad
+                state_not: unavailable
+            - entity: climate.duncan
+              features_position: bottom
+              state_content:
+              - state
+              - current_temperature
+              - temperature
+              type: tile
+              vertical: true
+              visibility:
+              - condition: state
+                entity: climate.duncan
+                state_not: unavailable
+            type: horizontal-stack
+          type: vertical-stack
+          visibility:
+          - condition: state
+            entity: input_boolean.show_og_thermostat
+            state: 'on'
+        type: vertical-stack
+      - cards:
+        - badges:
+          - color: state
+            entity: sensor.eg_temperatur
+            show_icon: false
+            show_state: true
+            state_content: state
+            tap_action:
+              action: more-info
+            type: entity
+          entity: input_boolean.show_eg_thermostat
+          heading: EG Thermostate
+          heading_style: title
+          icon: mdi:fridge
+          tap_action:
+            action: toggle
+          type: heading
+        - cards:
+          - cards:
+            - entity: climate.kuche
+              features_position: bottom
+              state_content:
+              - state
+              - temperature
+              - current_temperature
+              type: tile
+              vertical: true
+              visibility:
+              - condition: state
+                entity: climate.kuche
+                state_not: unavailable
+            - entity: climate.wohnzimmer
+              features_position: bottom
+              state_content:
+              - state
+              - temperature
+              - current_temperature
+              type: tile
+              vertical: true
+              visibility:
+              - condition: state
+                entity: climate.wohnzimmer
+                state_not: unavailable
+            type: horizontal-stack
+          type: horizontal-stack
+          visibility:
+          - condition: state
+            entity: input_boolean.show_eg_thermostat
+            state: 'on'
+        type: vertical-stack
+      type: vertical-stack
     icon: mdi:garage
     path: kontrollzentrum
     title: Kontrollzentrum
@@ -9363,105 +9494,3 @@ config:
     visible:
     - user: 4f7767cac0c342edb25e991662a2f56c
     - user: e7fe7b076dbb49a3aaa82b75c63cc302
-  - cards: []
-    icon: mdi:home-thermometer
-    max_columns: 1
-    path: klima
-    sections:
-    - cards:
-      - heading: OG
-        heading_style: title
-        icon: mdi:fridge
-        type: heading
-      - entity: climate.153931628718174_climate
-        features_position: bottom
-        grid_options:
-          rows: 1
-        name: Schlafzimmer
-        state_content:
-        - state
-        - temperature
-        - current_temperature
-        type: tile
-        vertical: true
-        visibility:
-        - condition: state
-          entity: climate.153931628718174_climate
-          state_not: unavailable
-      - entity: climate.bad
-        features_position: bottom
-        state_content:
-        - state
-        - current_temperature
-        - temperature
-        type: tile
-        vertical: true
-        visibility:
-        - condition: state
-          entity: climate.bad
-          state_not: unavailable
-      - entity: climate.kinderbad
-        features_position: bottom
-        state_content:
-        - state
-        - current_temperature
-        - temperature
-        type: tile
-        vertical: true
-        visibility:
-        - condition: state
-          entity: climate.kinderbad
-          state_not: unavailable
-      - entity: climate.duncan
-        features_position: bottom
-        state_content:
-        - state
-        - current_temperature
-        - temperature
-        type: tile
-        vertical: true
-        visibility:
-        - condition: state
-          entity: climate.duncan
-          state_not: unavailable
-      - heading: EG
-        heading_style: title
-        type: heading
-        visibility:
-        - condition: and
-          conditions:
-          - condition: state
-            entity: climate.kuche
-            state_not: unavailable
-          - condition: state
-            entity: climate.wohnzimmer
-            state_not: unavailable
-      - entity: climate.kuche
-        features_position: bottom
-        state_content:
-        - state
-        - temperature
-        - current_temperature
-        type: tile
-        vertical: true
-        visibility:
-        - condition: state
-          entity: climate.kuche
-          state_not: unavailable
-      - entity: climate.wohnzimmer
-        features_position: bottom
-        state_content:
-        - state
-        - temperature
-        - current_temperature
-        type: tile
-        vertical: true
-        visibility:
-        - condition: state
-          entity: climate.wohnzimmer
-          state_not: unavailable
-      type: grid
-    - cards: []
-      type: grid
-    title: Klima
-    type: sections


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced interactive, toggleable thermostat groups for upstairs and downstairs within the "Wintergarten Dachfenster" section.
  - Added badges displaying current temperatures for each floor.
  - Enhanced layout with more structured grouping and visibility toggles for thermostat tiles by floor.

- **Refactor**
  - Replaced the previous simple climate control view with a more organized and visually detailed layout, improving usability and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->