### PR TITLE
Add title property to vertical-stack card in Thermostate section

### DIFF
--- a/lovelace/lovelace.yaml
+++ b/lovelace/lovelace.yaml
@@ -5137,7 +5137,6 @@ config:
           - condition: state
             entity: input_boolean.show_og_thermostat
             state: 'on'
-        title: Thermostate
         type: vertical-stack
       - cards:
         - badges:
@@ -5189,6 +5188,7 @@ config:
             entity: input_boolean.show_eg_thermostat
             state: 'on'
         type: vertical-stack
+      title: Thermostate
       type: vertical-stack
     icon: mdi:garage
     path: kontrollzentrum


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the "Thermostate" section to display a title labeled "Thermostate" in the vertical-stack card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->