### PR TITLE
Add toggleable sections for outdated Open Beken and Tasmota device lists

### DIFF
--- a/lovelace/lovelace.dashboard_analysis.yaml
+++ b/lovelace/lovelace.dashboard_analysis.yaml
@@ -583,12 +583,16 @@ config:
   - badges: []
     cards:
     - cards:
-      - entity: sensor.openbk7231t_app_newest_version
-        fill_container: true
-        icon_type: none
-        primary_info: state
-        secondary_info: name
-        type: custom:mushroom-entity-card
+      - badges:
+        - entity: sensor.openbk7231t_app_newest_version
+          type: entity
+        entity: input_boolean.show_open_beken_updates
+        heading: Open Beken
+        heading_style: title
+        icon: mdi:fridge
+        tap_action:
+          action: toggle
+        type: heading
       - card:
           type: entities
         filter:
@@ -601,14 +605,22 @@ config:
         sort:
           method: state
         type: custom:auto-entities
+        visibility:
+        - condition: state
+          entity: input_boolean.show_open_beken_updates
+          state: 'on'
       type: vertical-stack
     - cards:
-      - entity: sensor.tasmota_newest_version
-        fill_container: true
-        icon_type: none
-        primary_info: state
-        secondary_info: name
-        type: custom:mushroom-entity-card
+      - badges:
+        - entity: sensor.tasmota_newest_version
+          type: entity
+        entity: input_boolean.show_tasmota_updates
+        heading: Tasmota
+        heading_style: title
+        icon: mdi:fridge
+        tap_action:
+          action: toggle
+        type: heading
       - card:
           type: entities
         filter:
@@ -621,6 +633,10 @@ config:
         sort:
           method: state
         type: custom:auto-entities
+        visibility:
+        - condition: state
+          entity: input_boolean.show_tasmota_updates
+          state: 'on'
       type: vertical-stack
     icon: mdi:power-socket-de
     path: tasmota


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added interactive toggles to show or hide update details for Open Beken and Tasmota device sections on the dashboard.
  - Each section now features a heading with an icon and tap action for improved visibility control.

- **Enhancements**
  - Device lists for outdated versions are now displayed conditionally based on toggle status, providing a cleaner and more customizable dashboard experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->