### PR TITLE
Add ESPHome config for ESP32-C3 with DHT22 and update Lovelace settings

### DIFF
--- a/esphome/esp32-c3-mini--dht22-compact-sensor.yaml
+++ b/esphome/esp32-c3-mini--dht22-compact-sensor.yaml
@@ -1,0 +1,132 @@
+substitutions:
+  name: esp32-c3-mini--dht22-sensor
+  friendly_name: ESP32 C3 mini - DHT22 Compact
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendly_name}
+  min_version: 2024.6.0
+  name_add_mac_suffix: false
+  on_boot: 
+    then:
+      - button.press: status_led_btn
+esp32:
+  board: esp32-c3-devkitm-1
+  framework:
+    type: arduino
+
+# Enable logging
+logger:
+  level: VERBOSE
+  initial_level: INFO
+
+select:
+  - platform: logger
+    name: Logger Level 
+    id: logger_select
+
+# Enable Home Assistant API
+api:
+  encryption:
+    key: "AXfsQvDFfThiaps/L9S07/t/2DHDBJ7U04cOm4pHEWY="
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+wifi:
+  networks:
+    - ssid: !secret wifi_ssid
+      password: !secret wifi_password
+      priority: 10
+      manual_ip: 
+        gateway: 192.168.2.1
+        dns1: 192.168.2.1
+        static_ip: 192.168.2.45
+        subnet: 255.255.255.0
+    - ssid: !secret wifi_ssid2
+      password: !secret wifi_password
+      priority: 8
+      manual_ip: 
+        gateway: 192.168.2.1
+        dns1: 192.168.2.1
+        static_ip: 192.168.2.45
+        subnet: 255.255.255.0
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "DHT22 Compact Fallback Hotspot"
+    password: !secret ap_password
+
+captive_portal:
+
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: IP Address
+
+output:
+  - platform: gpio
+    pin: 
+      number: GPIO8
+      ignore_strapping_warning: True
+      inverted: True
+    id: led_blue
+
+button:
+  - platform: output
+    output: led_blue
+    name: Status LED
+    id: status_led_btn
+    duration: 
+      milliseconds: 250
+
+  - platform: restart
+    name: Restart
+
+binary_sensor:
+  - platform: status
+    name: Status
+    id: status_bin
+    on_state: 
+      then:
+        - if: 
+            condition: 
+              - binary_sensor.is_on: status_bin
+            then: 
+              - button.press: status_led_btn
+
+sensor:  
+  - platform: dht
+    update_interval: 15s
+    pin: GPIO4
+    temperature: 
+      accuracy_decimals: 2
+      name: Temperature
+      id: temperature
+      filters:
+        - or:
+          - throttle: 120s
+          - delta: 4%
+    humidity: 
+      accuracy_decimals: 2
+      name: Humidity
+      id: humidity
+      filters:
+        - or:
+          - throttle: 120s
+          - delta: 4%
+
+  - platform: uptime
+    name: Uptime
+    update_interval: 60s
+
+  - platform: wifi_signal # Reports the WiFi signal strength/RSSI in dB
+    name: WiFi Signal dB
+    id: wifi_signal_db
+    update_interval: 5s
+    entity_category: "diagnostic"
+    filters: 
+        - or: 
+          - throttle: 120s
+          - delta: 2%

--- a/lovelace/lovelace.test_sankey.yaml
+++ b/lovelace/lovelace.test_sankey.yaml
@@ -127,6 +127,9 @@ config:
             - sensor.energy_monitoring_smartplug_leistung
             - sensor.bad_spiegellicht_power
             - sensor.orangina_lampe_zigbee_power
+            children_sum:
+              reconcile_to: max
+              should_be: equal_or_less
             color: '#039BE5'
             entity_id: sensor.known_power
             name: Monitored
@@ -385,6 +388,9 @@ config:
             - sensor.herd_energy_today
             - sensor.ac_din_rail_switch_energy_today
             - sensor.zirkulationspumpe_energy_today
+            children_sum:
+              reconcile_to: max
+              should_be: equal_or_less
             color: '#039BE5'
             entity_id: sensor.known_energy
             name: Monitored
@@ -514,226 +520,6 @@ config:
     path: energy-distribution
     title: Energy Distribution
     type: panel
-  - cards:
-    - cards:
-      - type: energy-date-selection
-      - convert_units_to: ''
-        electricity_price: sensor.energy_price_weinbergstr_9
-        energy_date_selection: true
-        height: 400
-        layout: horizontal
-        min_box_distance: 5
-        min_box_height: 5
-        min_box_size: 10
-        min_state: 0
-        round: 2
-        sections:
-        - entities:
-          - children:
-            - sensor.esp32_s3_zero_deye8k_total_charge_of_the_battery
-            - sensor.daily_netzeinspeisung
-            - total
-            color: var(--warning-color)
-            entity_id: sensor.scb_energy_yield_day
-            type: entity
-          - children:
-            - sensor.esp32_s3_zero_deye8k_total_charge_of_the_battery
-            - sensor.daily_netzeinspeisung
-            - total
-            color: var(--warning-color)
-            entity_id: sensor.bkw_outlet_1_energy_today
-            type: entity
-          - children:
-            - sensor.esp32_s3_zero_deye8k_total_charge_of_the_battery
-            - sensor.daily_netzeinspeisung
-            - total
-            color: var(--warning-color)
-            entity_id: sensor.esp32_s3_zero_deye8k_total_discharge_of_the_battery
-            type: entity
-          - children:
-            - sensor.esp32_s3_zero_deye8k_total_charge_of_the_battery
-            - sensor.daily_netzeinspeisung
-            - total
-            color: var(--warning-color)
-            entity_id: sensor.daily_deye_pv_production
-            type: entity
-          - children:
-            - sensor.esp32_s3_zero_deye8k_total_charge_of_the_battery
-            - sensor.daily_netzeinspeisung
-            - total
-            color: var(--success-color)
-            entity_id: sensor.esp32_s3_zero_deye8k_total_charge_of_the_battery
-            subtract_entities:
-            - sensor.esp32_s3_zero_deye8k_total_charge_of_the_battery
-            type: entity
-          - children:
-            - sensor.esp32_s3_zero_deye8k_total_charge_of_the_battery
-            - sensor.daily_netzeinspeisung
-            - total
-            entity_id: sensor.daily_netzbezug
-            subtract_entities:
-            - sensor.daily_netzeinspeisung
-            type: entity
-        - entities:
-          - children: []
-            color: var(--success-color)
-            entity_id: sensor.esp32_s3_zero_deye8k_total_charge_of_the_battery
-            subtract_entities:
-            - sensor.esp32_s3_zero_deye8k_total_discharge_of_the_battery
-            type: entity
-          - children: []
-            entity_id: sensor.daily_netzeinspeisung
-            subtract_entities:
-            - sensor.daily_netzbezug
-            type: entity
-          - children:
-            - garage
-            - kuche
-            - heizraum
-            - waschkuche
-            - terrarium
-            - gartenhaus
-            - server
-            - duncan
-            - unknown
-            entity_id: total
-            name: Total Consumption
-            type: remaining_parent_state
-        - entities:
-          - children:
-            - sensor.daily_energy_goe_11kw
-            - sensor.daily_energy_goe_22kw
-            - sensor.kuhlschrank_draussen_energy_today
-            - sensor.garagentor_energy_today
-            entity_id: garage
-            name: Garage
-            type: remaining_child_state
-          - children:
-            - sensor.kuhlschrank_drinnen_energy_today
-            - sensor.backofen_energy_today
-            - sensor.mikrowelle_energy_today_2
-            - sensor.spulmaschine_energy_today
-            - sensor.kaffeemaschine_energy_today
-            - sensor.kaffeemaschine_delonghi_energy_today
-            entity_id: kuche
-            name: "K\xFCche"
-            type: remaining_child_state
-          - children:
-            - sensor.sauger_energy_today
-            - sensor.heizung_energy_today
-            entity_id: heizraum
-            name: Heizraum
-            type: remaining_child_state
-          - children:
-            - sensor.trockner_energy_today
-            - sensor.waschmaschine_energy_today
-            - sensor.gefrierschrank_energy_today
-            entity_id: waschkuche
-            name: "Waschk\xFCche"
-            type: remaining_child_state
-          - children:
-            - sensor.terrarium_energy_today
-            entity_id: terrarium
-            name: Terrarium
-            type: remaining_child_state
-          - children:
-            - sensor.pool_pumpe_energy_today
-            entity_id: gartenhaus
-            name: Gartenhaus
-            type: remaining_child_state
-          - children:
-            - sensor.smart_plug_energy_today
-            - sensor.o2_router_energy_today
-            entity_id: server
-            name: Server
-            type: remaining_child_state
-          - children:
-            - sensor.duncan_daily_energy
-            - sensor.ankermake_energy_today
-            entity_id: duncan
-            name: Duncan
-            type: remaining_child_state
-          - children: []
-            entity_id: unknown
-            name: Unknown
-            type: remaining_parent_state
-          sort_group_by_parent: true
-        - entities:
-          - children: []
-            entity_id: sensor.daily_energy_goe_11kw
-            type: entity
-          - children: []
-            entity_id: sensor.daily_energy_goe_22kw
-            type: entity
-          - children: []
-            entity_id: sensor.kuhlschrank_draussen_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.garagentor_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.kuhlschrank_drinnen_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.backofen_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.mikrowelle_energy_today_2
-            type: entity
-          - children: []
-            entity_id: sensor.spulmaschine_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.kaffeemaschine_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.sauger_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.heizung_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.trockner_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.waschmaschine_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.kaffeemaschine_delonghi_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.gefrierschrank_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.terrarium_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.pool_pumpe_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.smart_plug_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.o2_router_energy_today
-            type: entity
-          - children: []
-            entity_id: sensor.duncan_daily_energy
-            type: entity
-          - children: []
-            entity_id: sensor.ankermake_energy_today
-            type: entity
-          sort_group_by_parent: true
-        show_names: true
-        show_states: true
-        show_units: true
-        type: custom:sankey-chart
-        unit_prefix: k
-        wide: true
-      type: vertical-stack
-    path: test
-    title: Energy Summary
-    type: panel
-    visible: []
   - cards:
     - battery:
         animate: false
@@ -901,11 +687,11 @@ config:
         convert_units_to: ''
         energy_date_selection: true
         gas_co2_intensity: 2351.6459999999997
-        height: 250
-        layout: vertical
+        height: 200
+        layout: auto
         min_box_distance: 5
         min_box_size: 3
-        min_state: 0
+        min_state: 0.05
         round: 1
         sections: []
         show_names: true

--- a/lovelace/lovelace_resources.yaml
+++ b/lovelace/lovelace_resources.yaml
@@ -22,7 +22,7 @@ items:
   url: /hacsfiles/uptime-card/uptime-card.js?hacstag=3505098670150
 - id: f9968791010c4d4cbe0ee283d16cfed4
   type: module
-  url: /hacsfiles/ha-sankey-chart/ha-sankey-chart.js?hacstag=455846088381
+  url: /hacsfiles/ha-sankey-chart/ha-sankey-chart.js?hacstag=455846088393
 - id: 8c12e8a9617f46d789549be977b01119
   type: module
   url: /hacsfiles/scheduler-card/scheduler-card.js?hacstag=2862701573215
@@ -125,3 +125,6 @@ items:
 - id: 3df909eb117c413fb826ed535ae6aff6
   type: module
   url: /hacsfiles/pv-forecast-card/clock_pv_forecast_card.js?hacstag=998247638110
+- id: f1259bdef0354267a65e178c5d6a880f
+  type: module
+  url: /hacsfiles/ring-tile-card/ring-tile-card.js?hacstag=991075417101


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new ESPHome configuration for an ESP32-C3 mini board with DHT22 sensor, supporting temperature, humidity, uptime, WiFi signal reporting, and Home Assistant integration.

- **Improvements**
  - Enhanced sensor group configuration in the energy dashboard with reconciliation rules for child sums.
  - Updated Sankey chart settings in the energy score panel for improved layout and thresholds.
  - Added a new Ring Tile Card resource and updated an existing module resource for Lovelace dashboards.

- **Removals**
  - Removed a nested energy summary panel card from the Lovelace test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->