### PR TITLE
Translate Lovelace sun card text from German to English and update countdown display

### DIFF
--- a/lovelace/lovelace.yaml
+++ b/lovelace/lovelace.yaml
@@ -1614,11 +1614,10 @@ config:
       entity: sun.sun
       name: "{% set sunrise = as_datetime(states('sensor.sun_next_rising')) %} {%\
         \ set sunset = as_datetime(states('sensor.sun_next_setting')) %} {% if sunrise\
-        \ and sunset %}\n  {% if sunrise < sunset %}\n    N\xE4chster Aufgang: {{\
-        \ sunrise.timestamp() | timestamp_custom('%H:%M', true) }}\n  {% else %}\n\
-        \    N\xE4chster Untergang: {{ sunset.timestamp() | timestamp_custom('%H:%M',\
-        \ true) }}\n  {% endif %}\n{% else %}\n  Sonneninfo nicht verf\xFCgbar\n{%\
-        \ endif %}\n"
+        \ and sunset %}\n  {% if sunrise < sunset %}\n    Next Rise: {{ sunrise.timestamp()\
+        \ | timestamp_custom('%H:%M', true) }}\n  {% else %}\n    Next Setting: {{\
+        \ sunset.timestamp() | timestamp_custom('%H:%M', true) }}\n  {% endif %}\n\
+        {% else %}\n  Suninformation not available\n{% endif %}\n"
       percent: "{% set sunrise = as_datetime(states('sensor.sun_next_rising')) %}\
         \ {% set sunset = as_datetime(states('sensor.sun_next_setting')) %} {% set\
         \ now_time = now() %} {% if sunrise and sunset %}\n  {% if sunrise < sunset\
@@ -1641,7 +1640,7 @@ config:
         \ set minutes = (total_seconds % 3600) // 60 %}\n    {% set seconds = (total_seconds\
         \ % 60) %}\n    in\n    {% if days > 0 %}\n      {{ days }}d\n    {% endif\
         \ %}\n    {{ '%02d:%02d:%02d' | format(hours | int, minutes | int, seconds\
-        \ | int) }}\n  {% else %}\n    00:00:00\n  {% endif %}\n{% else %}\n  --:--:--\n\
+        \ | int) }}\n  {% else %}\n    now\n  {% endif %}\n{% else %}\n  --:--:--\n\
         {% endif %}\n"
       tap_action:
         action: more-info


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated sun event card in the Lovelace UI to display English text ("Next Rise", "Next Setting", "Suninformation not available") instead of German.
  - Changed the fallback display for the sun event countdown from "00:00:00" to "now" when the event time is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->