### PR TITLE
Remove trockner_actionable_duncan and revise dryer notification script

### DIFF
--- a/config/scripts.yaml
+++ b/config/scripts.yaml
@@ -1584,84 +1584,55 @@ restart_internet:
   description: ''
   mode: restart
   max_exceeded: silent
-trockner_actionable_duncan:
-  use_blueprint:
-    path: homeassistant/confirmable_notification.yaml
-    input:
-      notify_device: 1acbf8ccc41c43655002000aa5b1cd46
-      title: Trockner fertig
-      confirm_text: Ausgeräumt
-      dismiss_text: Mach ich noch
-      confirm_action:
-      - action: input_boolean.turn_off
-        metadata: {}
-        data: {}
-        target:
-          entity_id: input_boolean.trockner_fertig
-      message: Bitte ausräumen
-  alias: Trockner Actionable Duncan
-  description: ''
 test_duncan_notify_response_echo:
-  alias: Test Duncan Confirm & Deny with Clear Notification
+  alias: Notify Duncan about Trockner Confirm & Deny with Clear Notification
   mode: restart
   sequence:
   - alias: Send confirmable notification via notify.duncan
     data:
-      title: Test
-      message: Doppelt gemoppelt
+      title: bitte ausräumen
+      message: Trockner fertig
       data:
-        tag: test_duncan_confirm
+        tag: confirmable_notify_trockner
         actions:
         - action: CONFIRM
-          title: 'Yes'
+          title: Erledigt
         - action: DENY
-          title: 'No'
+          title: Muss man noch machen
     action: notify.duncan
   - alias: Wait for button click
     wait_for_trigger:
-    - platform: event
-      event_type: mobile_app_notification_action
+    - event_type: mobile_app_notification_action
       event_data:
         action: CONFIRM
-    - platform: event
-      event_type: mobile_app_notification_action
+      trigger: event
+    - event_type: mobile_app_notification_action
       event_data:
         action: DENY
+      trigger: event
   - alias: Custom action based on button
     choose:
     - conditions:
       - condition: template
         value_template: '{{ wait.trigger.event.data.action == ''CONFIRM'' }}'
       sequence:
+      - action: input_boolean.turn_off
+        metadata: {}
+        data: {}
+        target:
+          entity_id: input_boolean.trockner_fertig
       - data:
-          title: ✅ Bestätigung
-          message: Du hast 'Yes' gewählt.
+          title: Trockner ausgeräumt von {{ states.person|selectattr("attributes.user_id",
+            "==", wait.trigger.event.context.user_id)|map(attribute="attributes.friendly_name")|first
+            }}
+          message: Danke
+          data:
+            tag: confirmable_notify_trockner
         action: notify.duncan
+      - delay: 00:00:15
       - data:
           message: clear_notification
           data:
-            tag: test_duncan_confirm
+            tag: confirmable_notify_trockner
         action: notify.duncan
-    - conditions:
-      - condition: template
-        value_template: '{{ wait.trigger.event.data.action == ''DENY'' }}'
-      sequence:
-      - data:
-          title: ❌ Ablehnung
-          message: Du hast 'No' gewählt.
-        action: notify.duncan
-      - data:
-          message: clear_notification
-          data:
-            tag: test_duncan_confirm
-        action: notify.duncan
-    default:
-    - data:
-        title: ⚠️ Unbekannte Antwort
-        message: Die Antwort konnte nicht erkannt werden.
-      action: notify.duncan
-    - data:
-        message: clear_notification
-        data:
-          tag: test_duncan_confirm
-      action: notify.duncan
+      alias: Trockner ausgeräumt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved dryer notification: Users now receive a confirmable notification when the dryer is finished, with clear "Done" and "Needs more work" options.
  - Personalized confirmation: If confirmed, a thank-you message is sent, showing who confirmed the dryer is done.
  - Enhanced notification handling: If denied, users receive a follow-up notification and the alert is cleared automatically.

- **Chores**
  - Removed the previous dryer notification script and replaced it with the updated, streamlined version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->