### PR TITLE
Add conditional battery level badges and update section icons in Lovelace YAML

### DIFF
--- a/lovelace/lovelace.yaml
+++ b/lovelace/lovelace.yaml
@@ -799,7 +799,16 @@ config:
     - cards:
       - card:
           cards:
-          - heading: Dreame D9 Max
+          - badges:
+            - entity: sensor.d9_max_gen_2_battery_level
+              show_icon: true
+              show_state: true
+              type: entity
+              visibility:
+              - below: 100
+                condition: numeric_state
+                entity: sensor.d9_max_gen_2_battery_level
+            heading: Dreame D9 Max
             heading_style: title
             icon: mdi:robot-vacuum
             type: heading
@@ -833,7 +842,16 @@ config:
         type: conditional
       - card:
           cards:
-          - heading: Dreame D10 Plus
+          - badges:
+            - entity: sensor.dreamebot_d10_plus_battery_level
+              show_icon: true
+              show_state: true
+              type: entity
+              visibility:
+              - below: 100
+                condition: numeric_state
+                entity: sensor.dreamebot_d10_plus_battery_level
+            heading: Dreame D10 Plus
             heading_style: title
             icon: mdi:robot-vacuum
             type: heading
@@ -868,35 +886,39 @@ config:
       - cards:
         - card:
             cards:
-            - cards:
-              - color: red
-                entity: binary_sensor.garagedoor_zigbee_contact
-                icon: ''
-                name: Garage Tor
-                state_content:
-                - state
-                - last-changed
-                type: tile
-                vertical: true
-              - card:
-                  entity: sensor.garagedoor_zigbee_battery
-                  name: Batterie
-                  state_content: state
-                  type: tile
-                  vertical: true
-                conditions:
+            - badges:
+              - entity: sensor.garagedoor_zigbee_battery_plus
+                show_icon: true
+                show_state: true
+                type: entity
+                visibility:
                 - condition: or
                   conditions:
                   - below: 30
                     condition: numeric_state
-                    entity: sensor.garagedoor_zigbee_battery
+                    entity: sensor.garagedoor_zigbee_battery_plus
                   - condition: state
-                    entity: sensor.garagedoor_zigbee_battery
+                    entity: sensor.garagedoor_zigbee_battery_plus
                     state: unavailable
-                type: conditional
-              type: vertical-stack
-            title: Garage
-            type: horizontal-stack
+              card_mod:
+                style: ".title ha-icon {\n  --card-mod-icon: {{ ' mdi:garage-open'\
+                  \ if is_state('binary_sensor.garagedoor_zigbee_contact', 'on') else\
+                  \ 'mdi:garage' }};\n}\n"
+              heading: Garage
+              heading_style: title
+              icon: mdi:garage
+              type: heading
+            - color: red
+              entity: binary_sensor.garagedoor_zigbee_contact
+              features_position: bottom
+              icon: ''
+              name: Garage Tor
+              state_content:
+              - state
+              - last-changed
+              type: tile
+              vertical: true
+            type: vertical-stack
           conditions:
           - condition: or
             conditions:
@@ -915,31 +937,35 @@ config:
           type: conditional
         - card:
             cards:
-            - cards:
-              - color: red
-                entity: binary_sensor.waschkuche_fenster_contact
-                features_position: bottom
-                icon: ''
-                name: "Waschk\xFCche Fenster "
-                state_content:
-                - state
-                - last-changed
-                type: tile
-                vertical: true
-              - card:
-                  entity: sensor.waschkuche_fenster_battery
-                  name: Batterie
-                  state_content: state
-                  type: tile
-                  vertical: true
-                conditions:
-                - below: 30
-                  condition: numeric_state
-                  entity: sensor.waschkuche_fenster_battery
-                type: conditional
-              type: vertical-stack
-            title: "Waschk\xFCche"
-            type: horizontal-stack
+            - badges:
+              - entity: sensor.waschkuche_fenster_battery_plus
+                show_icon: true
+                show_state: true
+                type: entity
+                visibility:
+                - condition: or
+                  conditions:
+                  - below: 30
+                    condition: numeric_state
+                    entity: sensor.waschkuche_fenster_battery
+                  - condition: state
+                    entity: sensor.waschkuche_fenster_battery
+                    state: unavailable
+              heading: "Wascgk\xFCche"
+              heading_style: title
+              icon: mdi:washing-machine
+              type: heading
+            - color: red
+              entity: binary_sensor.waschkuche_fenster_contact
+              features_position: bottom
+              icon: ''
+              name: "Waschk\xFCche Fenster "
+              state_content:
+              - state
+              - last-changed
+              type: tile
+              vertical: true
+            type: vertical-stack
           conditions:
           - condition: or
             conditions:
@@ -1025,6 +1051,20 @@ config:
             tap_action:
               action: more-info
             type: entity
+          - color: state
+            entity: sensor.boiler_battery_plus
+            show_icon: true
+            show_state: true
+            type: entity
+            visibility:
+            - condition: or
+              conditions:
+              - below: 30
+                condition: numeric_state
+                entity: sensor.boiler_battery_plus
+              - condition: state
+                entity: sensor.boiler_battery_plus
+                state: unavailable
           heading: Boiler
           heading_style: title
           type: heading
@@ -1126,7 +1166,22 @@ config:
     - cards:
       - card:
           cards:
-          - heading: Duncan
+          - badges:
+            - color: state
+              entity: sensor.t_h_duncan_zigbee_battery_plus
+              show_icon: true
+              show_state: true
+              type: entity
+              visibility:
+              - condition: or
+                conditions:
+                - below: 20
+                  condition: numeric_state
+                  entity: sensor.t_h_duncan_zigbee_battery
+                - condition: state
+                  entity: sensor.t_h_duncan_zigbee_battery_plus
+                  state: unavailable
+            heading: Duncan
             heading_style: title
             icon: ''
             type: heading
@@ -1156,24 +1211,6 @@ config:
                   navigation_path: /lovelace/duncan
                 type: tile
                 vertical: true
-              - card:
-                  entity: sensor.t_h_duncan_zigbee_battery
-                  features_position: bottom
-                  icon_tap_action:
-                    action: navigate
-                    navigation_path: /lovelace/duncan
-                  name: Battery
-                  state_content: temperature
-                  tap_action:
-                    action: navigate
-                    navigation_path: /lovelace/duncan
-                  type: tile
-                  vertical: true
-                conditions:
-                - below: 20
-                  condition: numeric_state
-                  entity: sensor.t_h_duncan_zigbee_battery
-                type: conditional
               - card:
                   card:
                     entity: sensor.esp32_c3_zero_epever_battery_voltage
@@ -1209,7 +1246,80 @@ config:
         type: conditional
       - card:
           cards:
-          - heading: Terrarium
+          - badges:
+            - color: state
+              entity: sensor.t_h_terra_lo_battery_plus
+              name: LO
+              show_icon: true
+              show_state: true
+              state_content:
+              - name
+              - state
+              type: entity
+              visibility:
+              - condition: or
+                conditions:
+                - below: 20
+                  condition: numeric_state
+                  entity: sensor.t_h_terra_lo_battery_plus
+                - condition: state
+                  entity: sensor.t_h_terra_lo_battery_plus
+                  state: unavailable
+            - color: state
+              entity: sensor.t_h_terra_lu_battery_plus
+              name: LU
+              show_icon: true
+              show_state: true
+              state_content:
+              - name
+              - state
+              type: entity
+              visibility:
+              - condition: or
+                conditions:
+                - below: 20
+                  condition: numeric_state
+                  entity: sensor.t_h_terra_lu_battery_plus
+                - condition: state
+                  entity: sensor.t_h_terra_lu_battery_plus
+                  state: unavailable
+            - color: state
+              entity: sensor.t_h_terra_ro_battery_plus
+              name: RO
+              show_icon: true
+              show_state: true
+              state_content:
+              - name
+              - state
+              type: entity
+              visibility:
+              - condition: or
+                conditions:
+                - below: 20
+                  condition: numeric_state
+                  entity: sensor.t_h_terra_ro_battery_plus
+                - condition: state
+                  entity: sensor.t_h_terra_ro_battery_plus
+                  state: unavailable
+            - color: state
+              entity: sensor.t_h_terra_ru_battery_plus
+              name: RU
+              show_icon: true
+              show_state: true
+              state_content:
+              - name
+              - state
+              type: entity
+              visibility:
+              - condition: or
+                conditions:
+                - below: 20
+                  condition: numeric_state
+                  entity: sensor.t_h_terra_ru_battery_plus
+                - condition: state
+                  entity: sensor.t_h_terra_ru_battery_plus
+                  state: unavailable
+            heading: Terrarium
             heading_style: title
             icon: mdi:snake
             type: heading
@@ -1229,6 +1339,7 @@ config:
               type: tile
               vertical: true
             - entity: sensor.t_h_terrarium_humidity
+              features_position: bottom
               hold_action:
                 action: more-info
               icon_tap_action:
@@ -1241,64 +1352,11 @@ config:
                 navigation_path: /lovelace/terrarium
               type: tile
               vertical: true
-            - card:
-                action: navigate
-                entity: sensor.t_h_terra_lo_battery
-                name: Batterie LO
-                navigation_path: /lovelace/terrarium
-                state_content: state
-                tap_action: null
-                type: tile
-                vertical: true
-              conditions:
-              - condition: state
-                entity: sensor.t_h_terra_lo_battery
-                state: '31'
-              hold_action:
-                action: more-info
-              icon_tap_action:
-                action: navigate
-                navigation_path: /lovelace/terrarium
-              type: conditional
-            - card:
-                entity: sensor.t_h_terra_lu_battery
-                name: Batterie LU
-                state_content: state
-                type: tile
-                vertical: true
-              conditions:
-              - below: 31
-                condition: numeric_state
-                entity: sensor.t_h_terra_lu_battery
-              type: conditional
-            - card:
-                entity: sensor.t_h_terra_ro_battery
-                name: Batterie Ro
-                state_content: state
-                type: tile
-                vertical: true
-              conditions:
-              - below: 31
-                condition: numeric_state
-                entity: sensor.t_h_terra_ro_battery
-              type: conditional
-            - card:
-                entity: sensor.t_h_terra_ru_battery
-                name: Batterie Ru
-                state_content: state
-                type: tile
-                vertical: true
-              conditions:
-              - condition: state
-                entity: sensor.t_h_terra_ru_battery
-                state: '31'
-              type: conditional
             type: horizontal-stack
           type: vertical-stack
         conditions:
         - condition: user
           users:
-          - e7fe7b076dbb49a3aaa82b75c63cc302
           - 4f7767cac0c342edb25e991662a2f56c
         - condition: state
           entity: input_boolean.terrarium_display_toggle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added battery level badges to multiple device sections, which appear only when battery is low or unavailable.
  * Garage and Waschküche sections now display battery status as badges with improved visibility conditions.
  * Garage heading icon now dynamically reflects door state.
  * Terrarium section now shows individual battery badges for each sensor.

* **Improvements**
  * Unified battery status display across sections for a more consistent user experience.
  * Minor layout and icon updates in relevant sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->