### PR TITLE
Disable two delay steps in terra_sunrise and update hacstag in JS resources 

### DIFF
--- a/config/scripts.yaml
+++ b/config/scripts.yaml
@@ -692,10 +692,12 @@ terra_sunrise:
             hours: 0
             minutes: 0
             seconds: 15
+      enabled: false
     - delay:
         hours: 0
         minutes: 0
         seconds: 15
+      enabled: false
     - action: light.turn_on
       metadata: {}
       data:

--- a/lovelace/lovelace_resources.yaml
+++ b/lovelace/lovelace_resources.yaml
@@ -7,7 +7,7 @@ items:
   url: /hacsfiles/lovelace-mushroom/mushroom.js?hacstag=444350375450
 - id: 59b58446d39d4abebef8ec4b4967a6af
   type: module
-  url: /hacsfiles/hass-swipe-navigation/swipe-navigation.js?hacstag=5017254791155
+  url: /hacsfiles/hass-swipe-navigation/swipe-navigation.js?hacstag=5017254791156
 - id: 3688f50c1a6c41d7b3ca3fd11fa24b54
   type: module
   url: /hacsfiles/lovelace-auto-entities/auto-entities.js?hacstag=1677445841161
@@ -94,7 +94,7 @@ items:
   url: /hacsfiles/lovelace-windrose-card/windrose-card.js?hacstag=5912706961251
 - id: 6138cdd21e5147e493316aa0b9087ebc
   type: module
-  url: /hacsfiles/simple-swipe-card/simple-swipe-card.js?hacstag=970744650240
+  url: /hacsfiles/simple-swipe-card/simple-swipe-card.js?hacstag=970744650250
 - id: 1c6874666863483c80341bd2685cc02d
   type: module
   url: /hacsfiles/jk-bms-card/jk-bms-card.js?hacstag=974898979117


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled two delay steps in the "terra_sunrise" automation script, so these delays will now be skipped.
  * Updated version tags for several Lovelace resource URLs to ensure the latest versions are loaded. No changes to resource functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->