### PR TITLE
Remove automation delay, simplify scripts, and update resource URL tag 

### DIFF
--- a/config/automations.yaml
+++ b/config/automations.yaml
@@ -2332,10 +2332,6 @@
     entity_id:
     - binary_sensor.luftbefeuchter_on_windows
     to: 'on'
-    for:
-      hours: 0
-      minutes: 1
-      seconds: 0
     id: Luftbefeuchter
   conditions:
   - condition: sun

--- a/config/scripts.yaml
+++ b/config/scripts.yaml
@@ -660,67 +660,26 @@ auto_boiler_off_300s:
 terra_sunrise:
   alias: Terra sunrise
   sequence:
-  - sequence:
-    - target:
-        entity_id: input_boolean.terrarium_on
-      data: {}
-      action: input_boolean.turn_on
-      continue_on_error: true
-    - type: turn_on
-      device_id: cb754e11257e7b140e732b51b3457d49
-      entity_id: d2af83dd14b0c3b04e2c8cdaf17b7d6b
-      domain: switch
-      continue_on_error: true
-    - data: {}
-      action: script.luftbefeuchter
-      continue_on_error: true
-    - delay:
-        hours: 0
-        minutes: 1
-        seconds: 0
-    - repeat:
-        count: 100
-        sequence:
-        - action: light.turn_on
-          metadata: {}
-          data:
-            brightness_step_pct: 1
-          continue_on_error: true
-          target:
-            entity_id: light.esp32_c3_mini_terrarium_lights_light_bar
-        - delay:
-            hours: 0
-            minutes: 0
-            seconds: 15
-      enabled: false
-    - delay:
-        hours: 0
-        minutes: 0
-        seconds: 15
-      enabled: false
-    - action: light.turn_on
-      metadata: {}
-      data:
-        brightness_pct: 95
-      target:
-        entity_id: light.esp32_c3_mini_terrarium_lights_light_bar
-      continue_on_error: true
-    - delay:
-        hours: 0
-        minutes: 0
-        seconds: 1
-    - action: light.turn_on
-      metadata: {}
-      data:
-        brightness_pct: 95
-      target:
-        entity_id: light.esp32_c3_mini_terrarium_lights_light_bar
-      continue_on_error: true
-    - type: turn_on
-      device_id: cb754e11257e7b140e732b51b3457d49
-      entity_id: 1b57dce94d224eba3ed8b7258f94ecf3
-      domain: switch
-      continue_on_error: true
+  - target:
+      entity_id: input_boolean.terrarium_on
+    data: {}
+    action: input_boolean.turn_on
+    continue_on_error: true
+  - action: switch.turn_on
+    metadata: {}
+    data: {}
+    target:
+      entity_id: switch.terrarium_tasmota2
+    continue_on_error: true
+  - data: {}
+    action: script.luftbefeuchter
+    continue_on_error: true
+  - action: switch.turn_on
+    metadata: {}
+    data: {}
+    target:
+      entity_id: switch.terrarium
+    continue_on_error: true
   mode: single
 luftbefeuchter:
   alias: Luftbefeuchter
@@ -795,50 +754,20 @@ terra_sunset:
     data: {}
     action: input_boolean.turn_off
     continue_on_error: true
-  - type: turn_off
-    device_id: cb754e11257e7b140e732b51b3457d49
-    entity_id: 1b57dce94d224eba3ed8b7258f94ecf3
-    domain: switch
+  - action: switch.turn_off
+    metadata: {}
+    data: {}
+    target:
+      entity_id: switch.terrarium
     continue_on_error: true
   - data: {}
     action: script.luftbefeuchter
     continue_on_error: true
-  - repeat:
-      sequence:
-      - action: light.turn_on
-        metadata: {}
-        data:
-          brightness_step_pct: -1
-        target:
-          entity_id:
-          - light.esp32_c3_mini_terrarium_lights_light_bar
-        continue_on_error: true
-      - delay:
-          hours: 0
-          minutes: 0
-          seconds: 1
-          milliseconds: 0
-      count: 101
-    enabled: false
-  - delay:
-      hours: 0
-      minutes: 0
-      seconds: 10
-      milliseconds: 0
-    enabled: false
-  - action: light.turn_off
+  - action: switch.turn_off
     metadata: {}
     data: {}
     target:
-      entity_id: light.esp32_c3_mini_terrarium_lights_light_bar
-  - delay:
-      hours: 0
-      minutes: 0
-      seconds: 10
-  - type: turn_off
-    device_id: cb754e11257e7b140e732b51b3457d49
-    entity_id: d2af83dd14b0c3b04e2c8cdaf17b7d6b
-    domain: switch
+      entity_id: switch.terrarium_tasmota2
     continue_on_error: true
   mode: single
 warmelampe:

--- a/lovelace/lovelace_resources.yaml
+++ b/lovelace/lovelace_resources.yaml
@@ -94,7 +94,7 @@ items:
   url: /hacsfiles/lovelace-windrose-card/windrose-card.js?hacstag=5912706961251
 - id: 6138cdd21e5147e493316aa0b9087ebc
   type: module
-  url: /hacsfiles/simple-swipe-card/simple-swipe-card.js?hacstag=970744650250
+  url: /hacsfiles/simple-swipe-card/simple-swipe-card.js?hacstag=970744650251
 - id: 1c6874666863483c80341bd2685cc02d
   type: module
   url: /hacsfiles/jk-bms-card/jk-bms-card.js?hacstag=974898979117


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automation for "Terra Pulsetime Control" now triggers immediately when the specified sensor turns on, instead of waiting for 1 minute.

* **Refactor**
  * Simplified the "terra_sunrise" and "terra_sunset" scripts by removing gradual light brightness adjustments and device-specific actions, streamlining them to basic on/off operations.

* **Chores**
  * Updated the version tag for the "simple-swipe-card" resource to ensure the latest version is loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->