### PR TITLE
Add description to automation and remove two history_stats sensors 

### DIFF
--- a/config/automations.yaml
+++ b/config/automations.yaml
@@ -7123,7 +7123,8 @@
   mode: single
 - id: '1749115504854'
   alias: Adjust Addon Status based on AnkerMake M5C Usage
-  description: ''
+  description: Starts or stops the Ankerctl addon based on the state of the AnkerMake
+    M5C switch
   triggers:
   - trigger: state
     entity_id:

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1057,25 +1057,6 @@ command_line:
       value_template: "{{ (value|int(0) / 1024) | round(3) }}"
 
 sensor:
-  - platform: history_stats
-    unique_id: time_in_bed_night
-    name: 'Time in Bed last 24h'
-    entity_id: binary_sensor.esp32_c3_mini_bett_nachtlicht_master_bed_occupied
-    state: "on"
-    type: time
-    start: "{{ today_at() - timedelta(hours=4) }}"
-    end: "{{ now() }}"
-    
-  - platform: history_stats
-    unique_id: time_on_schreibtischstuhl
-    name: 'Schreibtischstuhl Besetz Dauer'
-    entity_id: binary_sensor.nous_chair_sensor_zigbee_water_leak
-    state: "on"
-    type: time
-    end: "{{ now() }}"
-    duration:
-      hours: 24
-
   # Tasmota newest Version
   - platform: rest
     scan_interval: 43200


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a description to the automation that manages the Ankerctl addon based on AnkerMake M5C switch usage.

* **Refactor**
  * Removed two sensors that tracked bed and desk chair occupancy durations over the last 24 hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->