### PR TITLE
Update notification templates, automation modes, and dashboard release notes 

### DIFF
--- a/config/automations.yaml
+++ b/config/automations.yaml
@@ -612,6 +612,9 @@
       trigger_entity: binary_sensor.garagedoor_zigbee_contact
       friendly_name: Garagentor
       notify_services_string: notify.duncan
+      notification_message: The {{ friendly_name | default('') }} was left open at
+        {{ as_timestamp(initially_triggered_at) | timestamp_custom('%T', True) }}.
+      notification_title: The {{ friendly_name | default('') }} was left open
 - id: '1705857100421'
   alias: Waschmaschine fertig
   description: ''
@@ -671,9 +674,10 @@
         seconds: 0
         days: 0
       notify_services_string: notify.mobile_app_poco_f7
-      notification_message: Das {{ friendly_name }} ist offen seit {{ as_timestamp(now()
-        - timedelta(minutes=120)) | timestamp_custom('%T', True) }}.
-      notification_title: '{{ friendly_name }} offen'
+      notification_message: Das {{ friendly_name | default('') }} ist offen seit {{
+        as_timestamp(now() - timedelta(minutes=120)) | timestamp_custom('%T', True)
+        }}.
+      notification_title: '{{ friendly_name | default('''') }} offen'
       repeat_notification: true
       time_between_repeat_notification:
         hours: 3
@@ -4113,9 +4117,10 @@
     input:
       trigger_entity: binary_sensor.kinderbad_fenster_contact
       notify_services_string: notify.familie
-      notification_title: '{{ friendly_name }} offen'
-      notification_message: Das {{ friendly_name }} ist offen seit {{ as_timestamp(now()
-        - timedelta(minutes=10)) | timestamp_custom('%T', True) }}.
+      notification_title: '{{ friendly_name | default('''') }} offen'
+      notification_message: Das {{ friendly_name | default('') }} ist offen seit {{
+        as_timestamp(now() - timedelta(minutes=10)) | timestamp_custom('%T', True)
+        }}.
       duration_issue_state:
         hours: 0
         minutes: 10
@@ -4135,9 +4140,10 @@
     input:
       trigger_entity: binary_sensor.bad_fenster_contact
       notify_services_string: notify.familie
-      notification_title: '{{ friendly_name }} offen'
-      notification_message: Das {{ friendly_name }} ist offen seit {{ as_timestamp(now()
-        - timedelta(minutes=10)) | timestamp_custom('%T', True) }}.
+      notification_title: '{{ friendly_name | default('''') }} offen'
+      notification_message: Das {{ friendly_name | default('') }} ist offen seit {{
+        as_timestamp(now() - timedelta(minutes=10)) | timestamp_custom('%T', True)
+        }}.
       duration_issue_state:
         hours: 0
         minutes: 10
@@ -4157,9 +4163,10 @@
     input:
       trigger_entity: binary_sensor.gasteklo_fenster_contact
       notify_services_string: notify.familie
-      notification_title: '{{ friendly_name }} offen'
-      notification_message: Das {{ friendly_name }} ist offen seit {{ as_timestamp(now()
-        - timedelta(minutes=15)) | timestamp_custom('%T', True) }}.
+      notification_title: '{{ friendly_name | default('''') }} offen'
+      notification_message: Das {{ friendly_name | default('') }} ist offen seit {{
+        as_timestamp(now() - timedelta(minutes=15)) | timestamp_custom('%T', True)
+        }}.
       duration_issue_state:
         hours: 0
         minutes: 15
@@ -5261,9 +5268,10 @@
         seconds: 0
         days: 0
       notify_services_string: notify.familie
-      notification_title: '{{ friendly_name }} offen'
-      notification_message: Das {{ friendly_name }} ist offen seit {{ as_timestamp(now()
-        - timedelta(minutes=60)) | timestamp_custom('%T', True) }}.
+      notification_title: '{{ friendly_name | default('''') }} offen'
+      notification_message: Das {{ friendly_name | default('') }} ist offen seit {{
+        as_timestamp(now() - timedelta(minutes=60)) | timestamp_custom('%T', True)
+        }}.
 - id: '1737391841418'
   alias: Duncan Fenster offen
   description: ''
@@ -5272,9 +5280,11 @@
     input:
       trigger_entity: binary_sensor.duncan_fenster_contact
       notify_services_string: notify.familie
-      notification_title: '{{ friendly_name }} offen'
-      notification_message: '{{ friendly_name }} ist offen seit {{ as_timestamp(now()
-        - timedelta(minutes=10)) | timestamp_custom(''%T'', True) }}.'
+      notification_title: '{{ friendly_name | default('''') }} offen'
+      notification_message: '{{ friendly_name | default('''') }} ist offen seit {{
+        as_timestamp(now() - timedelta(minutes=10)) | timestamp_custom(''%T'', True)
+        }}.'
+      repeat_notification: false
 - id: '1738024300699'
   alias: Notify When UPS Changes State
   description: This automation sends a notification when the UPS changes its state,
@@ -7937,7 +7947,8 @@
     data: {}
     target:
       entity_id: switch.153931628718174_prompt_tone
-  mode: single
+  mode: queued
+  max: 10
 - id: '1754256267209'
   alias: UGREEN NAS Power Management
   description: Turns on the UGREEN NAS at 10:00 AM daily and turns it off if its power

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -789,6 +789,9 @@ template:
         at: "12:00:00"
       - trigger: homeassistant
         event: start
+      - trigger: state
+        entity_id:
+         - input_button.update_beta_release_notes
     actions:
       - action: multiscrape.scrape
         response_variable: beta_scrape

--- a/lovelace/lovelace.dashboard_analysis.yaml
+++ b/lovelace/lovelace.dashboard_analysis.yaml
@@ -483,6 +483,13 @@ config:
     - entity: todo.to_do_duncan
       hide_completed: true
       type: todo-list
+    - entity: sensor.home_assistant_beta_release_notes
+      tap_action:
+        action: perform-action
+        perform_action: input_button.press
+        target:
+          entity_id: input_button.update_beta_release_notes
+      type: custom:mushroom-entity-card
     - content: '{{ state_attr("sensor.home_assistant_beta_release_notes","ai_summary")
 
         }}'

--- a/lovelace/lovelace.yaml
+++ b/lovelace/lovelace.yaml
@@ -5748,29 +5748,6 @@ config:
               action: more-info
             type: custom:mushroom-entity-card
           type: horizontal-stack
-        - card:
-            collapsible_controls: true
-            double_tap_action:
-              action: toggle
-            entity: light.esp32_c3_mini_terrarium_lights_light_bar
-            fill_container: true
-            hold_action:
-              action: more-info
-            icon: mdi:ceiling-light
-            name: Light Bar
-            primary_info: name
-            secondary_info: state
-            show_brightness_control: true
-            show_color_temp_control: true
-            tap_action:
-              action: none
-            type: custom:mushroom-light-card
-            use_light_color: true
-          conditions:
-          - condition: state
-            entity: switch.terrarium_tasmota2
-            state: 'on'
-          type: conditional
         - content: "**\u23F0 Aktuelle Zeit:** `{{ now().strftime('%H:%M:%S') }}`\n\
             **\U0001F305 Offset-Zeiten**\n- Start: `{% set start = state_attr('binary_sensor.luftbefeuchter_on_windows',\
             \ 'next_sunrise_offset_start') %}{% if start %}{{ strptime(start, '%Y-%m-%d\


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dashboard card to display and summarize Home Assistant beta release notes, with a button to manually update the notes.

* **Bug Fixes**
  * Improved notification templates for open contact sensors to handle missing device names gracefully.
  * Enhanced timestamp formatting in notifications for clarity.

* **Improvements**
  * Updated automations to prevent repeated notifications for certain sensors.
  * Adjusted automation modes to allow multiple queued executions where appropriate.

* **Removals**
  * Removed a conditional card for terrarium light controls from the dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->