### PR TITLE
Adjust notification delay and add 28.5°C gate to Pool Heating ON 

### DIFF
--- a/config/automations.yaml
+++ b/config/automations.yaml
@@ -636,7 +636,7 @@
       end_notify_device: []
       end_message_title: Waschmaschine
       end_message: Waschmaschine ausräumen
-      end_time_delay: 1
+      end_time_delay: 0.75
       start_appliance_power: 30
       end_appliance_power: 10
       include_start_notify: enable_start_notify_options
@@ -2481,6 +2481,12 @@
       - condition: trigger
         id:
         - 'On'
+      - condition: not
+        conditions:
+        - condition: numeric_state
+          entity_id: input_number.pool_temp_start
+          above: 28.5
+        alias: Start Temp not too hot
       - condition: numeric_state
         entity_id: sensor.esp32_c3_mini_pool_temperature_pool_temperature
         below: input_number.pool_heating_stop


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a temperature safeguard to Pool Heating Control: solar heating won’t start if the pool start temperature exceeds 28.5°C.
- Bug Fixes
  - Reduced the “Waschmaschine fertig” end notification delay from 1s to 0.75s for faster alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 