### PR TITLE
Add 8 water monitors to 2-day purge; case-insensitive summary sort 

### DIFF
--- a/config/automations.yaml
+++ b/config/automations.yaml
@@ -4472,6 +4472,14 @@
           - sensor.lsjwh4097rn105299_last_vehicle_state
           - sensor.lsjwh4097rn105299_last_poll_error
           - binary_sensor.pool_temperatur_trend
+          - binary_sensor.water_monitor_low_flow_leak
+          - binary_sensor.water_monitor_intelligent_leak
+          - binary_sensor.water_monitor_daily_analysis_status
+          - binary_sensor.water_monitor_upstream_sensors_health
+          - sensor.water_monitor_current_session_volume
+          - sensor.water_monitor_last_session_average_flow
+          - sensor.water_monitor_last_session_duration
+          - sensor.water_monitor_last_session_volume
           entity_globs: sensor.esp32_s3_zero_deye8k*
     enabled: true
   - alias: Keep 3 Day

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,12 +1,6 @@
 # Loads default set of integrations. Do not remove.
 default_config:
 
-# # Temperory until next solarman logger relase with fix
-# logger:
-#   filters:
-#     homeassistant.helpers.entity_platform:
-#       - ".*The deprecated function platform_translations was called from solarman.*"
-
 recorder:
   purge_keep_days: 10
   commit_interval: 10
@@ -472,7 +466,12 @@ template:
                 {% endfor %}
               {% endfor %}
             
-              {{ combined.items }}
+              {# combined.items #}
+              
+              {# ---- SORTING STEP ---- #}
+              {% set sorted_items = combined.items | sort(attribute='s', case_sensitive=False) %}
+              {{ sorted_items }}
+              
             {% else %}
               []
             {% endif %}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kellervorräte: Combined Filtered Items are now sorted case-insensitively by summary for a clearer, consistent display.

* **Chores**
  * Expanded 2‑day data retention automation to include additional Water Monitor entities, ensuring these sensors and binary sensors are purged according to the 2‑day policy:
    - Low flow leak, intelligent leak, daily analysis status, upstream sensors health
    - Current session volume, last session average flow, last session duration, last session volume
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 