### PR TITLE
ESPHome EV: entity updates, MQTT min_amps, stop calc, loop, cleanup

### DIFF
--- a/esphome/es32-c3-mini--goe22-controll.yaml
+++ b/esphome/es32-c3-mini--goe22-controll.yaml
@@ -137,6 +137,7 @@ switch:
     optimistic: True
     id: never_stop_charging
     name: Dont Stop Charging ${variant}
+    restore_mode: ALWAYS_OFF
 
   - platform: template
     optimistic: True
@@ -226,7 +227,7 @@ number:
     mode: BOX
 
   - platform: template
-    name: Min Amperage
+    name: Min Amperage ${variant}
     id: min_amps
     initial_value: ${min_amps}
     min_value: ${min_amps}
@@ -307,16 +308,6 @@ text_sensor:
               - sensor.template.publish:
                   id: goe_amp_divider
                   state: 3
-              - if: 
-                  condition: 
-                    - sensor.in_range: 
-                        id: card_used
-                        above: 1.5
-                        below: 2.5
-                  then: 
-                    - number.set: 
-                        id: min_amps
-                        value: 8
 
   - platform: mqtt_subscribe
     topic: ${main_topic}nrg
@@ -408,29 +399,23 @@ sensor:
 
   - platform: mqtt_subscribe
     topic: ${main_topic}trx
-    name: Card Used
+    name: Card Used ${variant}
     id: card_used
     filters: 
       - round: 0
-
-  # - platform: mqtt_subscribe
-  #   topic: smart_meter/total_combined
-  #   accuracy_decimals: 2
-  #   state_class: measurement
-  #   device_class: power
-  #   unit_of_measurement: W
-  #   id: grid_gen
-  #   name: Smart Meter HA Power ${variant}
-  #   internal: False
-  #   filters: 
-  #     # - multiply: -1
-  #     - lambda: !lambda return x + id(battery_power_offset).state;
-
-  # - platform: template
-  #   name: Smart Meter MQTT Power $variant
-  #   id: smart_meter_power
-  #   unit_of_measurement: W
-  #   device_class: power
+    on_value_range: 
+      above: 1.5
+      below: 2.5
+      then:
+        - if:
+            condition:
+              - sensor.in_range:
+                  id: goe_amp_divider
+                  above: 2.5
+            then:
+              - number.set: 
+                  id: min_amps
+                  value: 8
 
   - platform: mqtt_subscribe
     topic: grid/power
@@ -602,19 +587,6 @@ sensor:
           min_value: 0
           max_value: ${max_amps}
 
-
-    #on_value:
-    #  then:
-    #    - if:
-    #        condition:
-    #          - switch.is_on: enable_pv_charging
-    #        then:
-    #          - script.execute: charge_ev
-    #        else:
-    #          - text_sensor.template.publish:
-    #              id: log_txt
-    #              state: "PV Surplus Charging OFF"
-
 interval:
   interval: 
     seconds: 10
@@ -631,9 +603,6 @@ interval:
            - script.execute: 
                 id: log_txt_queued
                 log_text: "PV Surplus Charging OFF"
-          # - text_sensor.template.publish:
-          #     id: log_txt
-          #     state: "PV Surplus Charging OFF"
 
 script:
   - id: log_txt_queued
@@ -662,9 +631,12 @@ script:
   - id: stop_charging
     mode: single
     then:
-      - number.set: # Set Amps to Min
+      # - number.set:
+      #     id: amps
+      #     value: ${min_amps}
+      - number.set: 
           id: amps
-          value: ${min_amps}
+          value: !lambda return id(min_amps).state;
       - if:
           condition:
             - switch.is_on: never_stop_charging
@@ -764,7 +736,6 @@ script:
     mode: single
     then: 
       - switch.turn_off: low_amp_flag
-      # - script.execute: start_charging
       - if: # Set amps to the calculated ones if not already done so, also skip if not enough solar or battery power is available to provide the requested amps
           condition: 
             - lambda: !lambda return id(amps_goe_calculated_rounded).state != id(feedback_amps).state;
@@ -794,9 +765,16 @@ script:
                       id: skip_counter
                   - script.stop: charge_ev
                 else:
+                  # - number.set: # set amps to calculated amps when enough solar or battery power is available
+                  #     id: amps
+                  #     value: !lambda return id(amps_goe_calculated_rounded).state;
                   - number.set: # set amps to calculated amps when enough solar or battery power is available
                       id: amps
-                      value: !lambda return id(amps_goe_calculated_rounded).state;
+                      value: !lambda |-
+                        return std::max(
+                          (float)id(amps_goe_calculated_rounded).state,
+                          (float)id(min_amps).state
+                        );
                   - script.execute: start_charging
                   - delay: 2s
                   - number.to_min: skip_counter # resetting skip counter since we dont skip anymore

--- a/esphome/esp32-c3-mini--goe11-controll.yaml
+++ b/esphome/esp32-c3-mini--goe11-controll.yaml
@@ -230,6 +230,16 @@ number:
     mode: BOX
 
   - platform: template
+    name: Min Amperage ${variant}
+    id: min_amps
+    initial_value: ${min_amps}
+    min_value: ${min_amps}
+    max_value: ${max_amps}
+    optimistic: True
+    step: 1
+    mode: BOX
+
+  - platform: template
     step: 1
     min_value: ${min_amps}
     max_value: ${max_amps}
@@ -361,7 +371,7 @@ text_sensor:
                 - sun.is_above_horizon:
                 - switch.is_off: enable_pv_charging
             then: 
-              - switch.turn_on: enable_pv_charging              
+              - switch.turn_on: enable_pv_charging
 
 sensor:
   - platform: wifi_signal
@@ -395,25 +405,6 @@ sensor:
     id: feedback_amps
     name: Goe Feedback Amperage ${variant}
     internal: True
-
-  # - platform: mqtt_subscribe
-  #   topic: smart_meter/total_combined
-  #   accuracy_decimals: 2
-  #   state_class: measurement
-  #   device_class: power
-  #   unit_of_measurement: W
-  #   id: grid_gen
-  #   name: Smart Meter HA Power ${variant}
-  #   internal: False
-  #   filters: 
-  #     # - multiply: -1
-  #     - lambda: !lambda return x + id(battery_power_offset).state;
-
-  # - platform: template
-  #   name: Smart Meter MQTT Power $variant
-  #   id: smart_meter_power
-  #   unit_of_measurement: W
-  #   device_class: power
 
   - platform: mqtt_subscribe
     topic: grid/power
@@ -585,18 +576,25 @@ sensor:
           min_value: 0
           max_value: ${max_amps}
 
-
-    #on_value:
-    #  then:
-    #    - if:
-    #        condition:
-    #          - switch.is_on: enable_pv_charging
-    #        then:
-    #          - script.execute: charge_ev
-    #        else:
-    #          - text_sensor.template.publish:
-    #              id: log_txt
-    #              state: "PV Surplus Charging OFF"
+  - platform: mqtt_subscribe
+    topic: ${main_topic}trx
+    name: Card Used ${variant}
+    id: card_used
+    filters: 
+      - round: 0
+    on_value_range: 
+      above: 1.5
+      below: 2.5
+      then:
+        - if:
+            condition:
+              - sensor.in_range:
+                  id: goe_amp_divider
+                  above: 2.5
+            then:
+              - number.set: 
+                  id: min_amps
+                  value: 8
 
 interval:
   interval: 

--- a/lovelace/lovelace_resources.yaml
+++ b/lovelace/lovelace_resources.yaml
@@ -94,7 +94,7 @@ items:
   url: /hacsfiles/lovelace-windrose-card/windrose-card.js?hacstag=5912706961251
 - id: 6138cdd21e5147e493316aa0b9087ebc
   type: module
-  url: /hacsfiles/simple-swipe-card/simple-swipe-card.js?hacstag=9707446502510
+  url: /hacsfiles/simple-swipe-card/simple-swipe-card.js?hacstag=9707446502511
 - id: 1c6874666863483c80341bd2685cc02d
   type: module
   url: /hacsfiles/jk-bms-card/jk-bms-card.js?hacstag=974898979118


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added “Min Amperage ${variant}” control and “Card Used ${variant}” sensor with automatic min-amps adjustment.
  - Introduced a periodic PV Surplus Charging loop for more consistent behavior.
- Changes
  - Renamed public entities to include ${variant}.
  - “Never Stop Charging” now restores to OFF after reboot.
  - Amperage now calculated dynamically (uses max of calculated and minimum).
  - Reduced/adjusted logging; removed automatic MQTT updates on amp changes.
- Removals
  - Removed legacy Smart Meter power sensors.
- Chores
  - Updated Lovelace resource URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Review: ESPHome EV Entity Updates, MQTT min_amps, Stop Calc, Loop, Cleanup

### PR: [#191](https://github.com/Duncan1106/HA-Config/pull/191)

#### Summary of Changes
- **New Features**
  - Added “Min Amperage ${variant}” number entity.
  - Added “Card Used ${variant}” sensor with logic to auto-adjust min_amps.
  - Introduced a periodic PV Surplus Charging loop for more consistent behavior.
- **Improvements**
  - Renamed public entities to include `${variant}` for clarity.
  - “Never Stop Charging” switch now restores to OFF after reboot (`restore_mode: ALWAYS_OFF`).
  - Amperage calculation now uses the max of calculated and minimum values (never goes below min_amps).
  - Reduced/adjusted logging; removed automatic MQTT updates on amp changes.
- **Removals**
  - Removed legacy Smart Meter power sensors.
- **Chores**
  - Updated Lovelace resource hacstag.

#### Files Changed
- `esphome/es32-c3-mini--goe22-controll.yaml`
- `esphome/esp32-c3-mini--goe11-controll.yaml`
- `lovelace/lovelace_resources.yaml`

#### Code & Config Highlights
- **Min Amperage Logic:**  
  New number entity with id `min_amps` and on_value_range logic to set it to 8 when Card Used is in range and divider is above threshold.
- **Never Stop Charging:**  
  Switch now restores to OFF after reboot for safety.
- **Amps Calculation:**  
  Uses `std::max` (lambda) to ensure amperage does not drop below min_amps.
- **MQTT & Logging:**  
  Streamlined updates and removed legacy sensors.
- **Lovelace Resource:**  
  Minor hacstag bump.

#### Suggestions / Checks Before Merging
1. **Lambda / std::max Usage:**  
   - Make sure `std::max` and lambda syntax compiles in your target ESPHome version.
   - If you hit a compile error, consider using `fmaxf` or ensure lambda returns float.
2. **on_value_range for mqtt_subscribe:**  
   - Confirm ESPHome supports `on_value_range` for `mqtt_subscribe` sensors in your version. If not, use `on_value` + lambda.
3. **Duplicate id Names:**  
   - If these YAMLs are for separate devices, duplicate ids are fine.
4. **Removed Smart Meter Sensors:**  
   - Double-check that no automations/dashboards still reference those sensors.
5. **Logging/MQTT Update Changes:**  
   - Notify users if external automations depended on old MQTT messages.
6. **Style/Nits:**  
   - Remove any leftover commented-out blocks for cleaner config.
   - Confirm Lovelace hacstag bump is intentional.

#### Testing Before Merge
- Local ESPHome compile for both YAML files.
- Flash/test device to verify new number entity, amps calculations, and switch restore behavior.
- Test Card Used MQTT payloads that should update min_amps.
- Reboot device to confirm switch restore.

#### Conclusion
- Robust improvement to entity naming, amperage logic, and safety.
- If compile/tests pass and integrations are updated, this is ready to merge!

