### PR TITLE
HA automation param change; ESPHome stop_charging amps=max; VW ID4 UI 

### DIFF
--- a/config/automations.yaml
+++ b/config/automations.yaml
@@ -630,7 +630,7 @@
       end_notify_device: []
       end_message_title: Waschmaschine
       end_message: Waschmaschine ausräumen
-      end_time_delay: 0.73
+      end_time_delay: 0.74
       start_appliance_power: 30
       end_appliance_power: 10
       include_start_notify: enable_start_notify_options

--- a/esphome/es32-c3-mini--goe22-controll.yaml
+++ b/esphome/es32-c3-mini--goe22-controll.yaml
@@ -643,7 +643,11 @@ script:
     then:
       - number.set: 
           id: amps
-          value: !lambda return id(min_amps).state;
+          value: !lambda |-
+            return std::max(
+              (float)id(amps_goe_calculated_rounded).state,
+              (float)id(min_amps).state
+            );
       - if:
           condition:
             - switch.is_on: never_stop_charging

--- a/lovelace/lovelace.yaml
+++ b/lovelace/lovelace.yaml
@@ -2223,9 +2223,6 @@ config:
               - condition: state
                 entity: select.go_echarger_252682_trx
                 state: Card 0
-              - condition: state
-                entity: select.go_echarger_252682_trx
-                state: Card 2
             type: conditional
           - card:
               entity: sensor.wvgzzze2zpe005371_battery_level


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VW ID.4 (22 kW) tile now only appears when Card 0 is selected, preventing incorrect display under Card 2.
  * Charging stop behavior updated to set current to the higher of the calculated value or the minimum, avoiding unnecessary undercurrent limits.

* **Chores**
  * Slightly adjusted the “Waschmaschine fertig” completion delay to fine-tune notification timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 